### PR TITLE
Use redis cache for KOPPS api and all apis use in kursinfo-web

### DIFF
--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -64,7 +64,16 @@ module.exports = {
     kursinfoApi: getEnv('API_KEY', devDefaults('123489')),
     kursplanApi: getEnv('KURSPLAN_API_KEY', devDefaults('5678')),
     kursPMApi: getEnv('KURS_PM_API_KEY', devDefaults('9876'))
+    // koppsApi: unpackKOPPSConfig('KOPPS_URI', devKoppsApi)
   },
+
+  nodeApi: {
+    kursinfoApi: unpackNodeApiConfig('API_URI', devInnovationApi),
+    kursplanApi: unpackNodeApiConfig('KURSPLAN_API_URI', devKursplanApi),
+    kursPMApi: unpackNodeApiConfig('KURS_PM_API_URI', devKursPMApi)
+  },
+
+  koppsApi: unpackKOPPSConfig('KOPPS_URI', devKoppsApi),
 
   // Authentication
   auth: {
@@ -74,14 +83,6 @@ module.exports = {
     ssoBaseURL: getEnv('CAS_SSO_URI', devSsoBaseURL)
   },
   ldap: unpackLDAPConfig('LDAP_URI', getEnv('LDAP_PASSWORD'), devLdap, ldapOptions),
-
-  // Service API's
-  nodeApi: {
-    kursinfoApi: unpackNodeApiConfig('API_URI', devInnovationApi),
-    kursplanApi: unpackNodeApiConfig('KURSPLAN_API_URI', devKursplanApi),
-    kursPMApi: unpackNodeApiConfig('KURS_PM_API_URI', devKursPMApi)
-  },
-  koppsApi: unpackKOPPSConfig('KOPPS_URI', devKoppsApi),
 
   // Cortina
   blockApi: {
@@ -103,7 +104,7 @@ module.exports = {
   cache: {
     koppsApi: {
       redis: unpackRedisConfig('REDIS_URI', devRedis),
-      expireTime: getEnv('KOPPS_API_CACHE_EXPIRE_TIME', 15 * 60) // 15 minuteS
+      expireTime: getEnv('KOPPS_API_CACHE_EXPIRE_TIME', 60 * 60) // 60 minuteS
     },
     kursinfoApi: {
       redis: unpackRedisConfig('REDIS_URI', devRedis),
@@ -115,7 +116,7 @@ module.exports = {
     },
     kursplanApi: {
       redis: unpackRedisConfig('REDIS_URI', devRedis),
-      expireTime: getEnv('KURSPLAN_API_CACHE_EXPIRE_TIME', 15 * 60) // 15 minutes
+      expireTime: getEnv('KURSPLAN_API_CACHE_EXPIRE_TIME', 60 * 60) // 60 minutes
     },
     cortinaBlock: {
       redis: unpackRedisConfig('REDIS_URI', devRedis)

--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -62,7 +62,6 @@ module.exports = {
   // API keys
   apiKey: {
     kursinfoApi: getEnv('API_KEY', devDefaults('123489')),
-    kursinfoApiCached: getEnv('API_KEY', devDefaults('123489')),
     kursplanApi: getEnv('KURSPLAN_API_KEY', devDefaults('5678')),
     kursPMApi: getEnv('KURS_PM_API_KEY', devDefaults('9876'))
   },
@@ -79,7 +78,6 @@ module.exports = {
   // Service API's
   nodeApi: {
     kursinfoApi: unpackNodeApiConfig('API_URI', devInnovationApi),
-    kursinfoApiCached: unpackNodeApiConfig('API_URI', devInnovationApi),
     kursplanApi: unpackNodeApiConfig('KURSPLAN_API_URI', devKursplanApi),
     kursPMApi: unpackNodeApiConfig('KURS_PM_API_URI', devKursPMApi)
   },
@@ -103,8 +101,21 @@ module.exports = {
     level: 'debug'
   },
   cache: {
-    kursinfoApiCached: {
-      redis: unpackRedisConfig('REDIS_URI', devRedis)
+    koppsApi: {
+      redis: unpackRedisConfig('REDIS_URI', devRedis),
+      expireTime: getEnv('KOPPS_API_CACHE_EXPIRE_TIME', 15 * 60) // 15 minuteS
+    },
+    kursinfoApi: {
+      redis: unpackRedisConfig('REDIS_URI', devRedis),
+      expireTime: getEnv('KURSINFO_API_CACHE_EXPIRE_TIME', 3 * 60) // 3 * 60 s = 3 MINUTES
+    },
+    kursPMApi: {
+      redis: unpackRedisConfig('REDIS_URI', devRedis),
+      expireTime: getEnv('KURSPM_API_CACHE_EXPIRE_TIME', 3 * 60) // 3 * 60 s = 3 MINUTES
+    },
+    kursplanApi: {
+      redis: unpackRedisConfig('REDIS_URI', devRedis),
+      expireTime: getEnv('KURSPLAN_API_CACHE_EXPIRE_TIME', 15 * 60) // 15 minutes
     },
     cortinaBlock: {
       redis: unpackRedisConfig('REDIS_URI', devRedis)

--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -19,7 +19,7 @@ const devInnovationApi = devDefaults('http://localhost:3001/api/kursinfo?default
 const devKursplanApi = devDefaults('http://localhost:3001/api/kursplan?defaultTimeout=10000')
 const devKoppsApi = devDefaults('https://api-r.referens.sys.kth.se/api/kopps/v2/')
 const devKursPMApi = devDefaults('http://localhost:3001/api/kurs-pm?defaultTimeout=10000')
-const devSessionKey = devDefaults('node-web.sid')
+const devSessionKey = devDefaults('kursinfo-web.sid')
 const devSessionUseRedis = devDefaults(true)
 const devRedis = devDefaults('redis://localhost:6379/')
 const devRedisUG = devDefaults('team-studam-ref-redis-193.redis.cache.windows.net:6380,password=password,ssl=True,abortConnect=False')
@@ -61,7 +61,8 @@ module.exports = {
 
   // API keys
   apiKey: {
-    kursinfoApi: getEnv('API_KEY', devDefaults('1234')),
+    kursinfoApi: getEnv('API_KEY', devDefaults('123489')),
+    kursinfoApiCached: getEnv('API_KEY', devDefaults('123489')),
     kursplanApi: getEnv('KURSPLAN_API_KEY', devDefaults('5678')),
     kursPMApi: getEnv('KURS_PM_API_KEY', devDefaults('9876'))
   },
@@ -78,9 +79,11 @@ module.exports = {
   // Service API's
   nodeApi: {
     kursinfoApi: unpackNodeApiConfig('API_URI', devInnovationApi),
+    kursinfoApiCached: unpackNodeApiConfig('API_URI', devInnovationApi),
     kursplanApi: unpackNodeApiConfig('KURSPLAN_API_URI', devKursplanApi),
     kursPMApi: unpackNodeApiConfig('KURS_PM_API_URI', devKursPMApi)
   },
+  koppsApi: unpackKOPPSConfig('KOPPS_URI', devKoppsApi),
 
   // Cortina
   blockApi: {
@@ -100,6 +103,9 @@ module.exports = {
     level: 'debug'
   },
   cache: {
+    kursinfoApiCached: {
+      redis: unpackRedisConfig('REDIS_URI', devRedis)
+    },
     cortinaBlock: {
       redis: unpackRedisConfig('REDIS_URI', devRedis)
     },
@@ -107,6 +113,7 @@ module.exports = {
       redis: unpackRedisConfig('UG_REDIS_URI', devRedisUG)
     }
   },
+  redisServer: unpackRedisConfig('REDIS_URI', devRedis),
 
   // Session
   sessionSecret: getEnv('SESSION_SECRET', devDefaults('1234567890')),
@@ -120,8 +127,6 @@ module.exports = {
     },
     redisOptions: unpackRedisConfig('REDIS_URI', devRedis)
   },
-
-  koppsApi: unpackKOPPSConfig('KOPPS_URI', devKoppsApi),
 
   appInsights: {
     instrumentationKey: getEnv('APPINSIGHTS_INSTRUMENTATIONKEY')

--- a/public/js/app/pages/CoursePage.jsx
+++ b/public/js/app/pages/CoursePage.jsx
@@ -2,7 +2,6 @@ import { Component } from 'inferno'
 import { inject, observer } from 'inferno-mobx'
 
 import Alert from 'inferno-bootstrap/dist/Alert'
-import Button from 'inferno-bootstrap/lib/Button'
 import Col from 'inferno-bootstrap/dist/Col'
 import Row from 'inferno-bootstrap/dist/Row'
 
@@ -12,7 +11,7 @@ import DropdownItem from 'inferno-bootstrap/dist/DropdownItem'
 import DropdownToggle from 'inferno-bootstrap/dist/DropdownToggle'
 
 import i18n from '../../../../i18n'
-import { EMPTY, FORSKARUTB_URL, ADMIN_URL, SYLLABUS_URL, COURSE_IMG_URL } from '../util/constants'
+import { EMPTY, FORSKARUTB_URL, SYLLABUS_URL } from '../util/constants'
 
 // Components
 import RoundInformationOneCol from '../components/RoundInformationOneCol.jsx'
@@ -131,10 +130,9 @@ class CoursePage extends Component {
     }
     courseImage = `${routerStore.browserConfig.imageStorageUri}${courseImage}`
 
-    if (routerStore.browserConfig.env === 'dev') {
-      console.log('routerStore in CoursePage', routerStore)
-    }
-
+    // if (routerStore.browserConfig.env === 'dev') {
+    //   console.log('routerStore in CoursePage', routerStore)
+    // }
 
     const courseInformationToRounds = {
       course_code: courseData.courseInfo.course_code,

--- a/server/api.js
+++ b/server/api.js
@@ -6,9 +6,11 @@ const redis = require('kth-node-redis')
 const connections = require('kth-node-api-call').Connections
 
 const opts = {
-  log: log,
-  redis: redis,
+  log,
+  redis,
+  cache: config.cache,
   timeout: 30000,
+  retryOnESOCKETTIMEDOUT: true,
   checkAPIs: true // performs api-key checks against the apis, if a "required" check fails, the app will exit. Required apis are specified in the config
 }
 

--- a/server/apiCalls/koppsCourseData.js
+++ b/server/apiCalls/koppsCourseData.js
@@ -37,5 +37,6 @@ async function getKoppsCourseData (courseCode, lang = 'sv') {
 }
 
 module.exports = {
+  koppsApi: api,
   getKoppsCourseData
 }

--- a/server/apiCalls/koppsCourseData.js
+++ b/server/apiCalls/koppsCourseData.js
@@ -2,20 +2,28 @@
 const log = require('kth-node-log')
 const config = require('../configuration').server
 const BasicAPI = require('kth-node-api-call').BasicAPI
+const redis = require('kth-node-redis')
 
+const cacheConfig = {
+  koppsApi: config.cache.koppsApi
+}
 const koppsApi = new BasicAPI({
+  log,
   hostname: config.koppsApi.host,
   basePath: config.koppsApi.basePath,
   https: true,
   json: true,
   // Kopps is a public API and needs no API-key
   defaultTimeout: config.koppsApi.defaultTimeout,
-  retryOnESOCKETTIMEDOUT: true,
-  redis: {
-    client: config.cache.koppsApi.redis,
-    prefix: 'koppsApi',
-    expire: config.cache.koppsApi.expireTime
-  }
+  // retryOnESOCKETTIMEDOUT: true,
+  timeout: 5000,
+  redis,
+  // {
+  //   client: config.cache.koppsApi.redis,
+  //   prefix: 'koppsApi',
+  //   expire: config.cache.koppsApi.expireTime
+  // },
+  cache: cacheConfig
 })
 
 module.exports = {
@@ -26,7 +34,7 @@ async function getKoppsCourseData (courseCode, lang = 'sv') {
   try {
     return await koppsApi.getAsync({uri: `course/${encodeURIComponent(courseCode)}/detailedinformation?l=${lang}`, useCache: true})
   } catch (err) {
-    log.debug('Kopps is not available')
-    throw err
+    log.debug('Kopps is not available', err)
+    return (err)
   }
 }

--- a/server/apiCalls/koppsCourseData.js
+++ b/server/apiCalls/koppsCourseData.js
@@ -12,7 +12,6 @@ const koppsApi = new BasicAPI({
   defaultTimeout: config.koppsApi.defaultTimeout
 })
 
-
 module.exports = {
   getKoppsCourseData: getKoppsCourseData
 }

--- a/server/apiCalls/koppsCourseData.js
+++ b/server/apiCalls/koppsCourseData.js
@@ -1,15 +1,21 @@
 'use strict'
-
+const log = require('kth-node-log')
 const config = require('../configuration').server
 const BasicAPI = require('kth-node-api-call').BasicAPI
 
 const koppsApi = new BasicAPI({
   hostname: config.koppsApi.host,
   basePath: config.koppsApi.basePath,
-  https: config.koppsApi.https,
+  https: true,
   json: true,
   // Kopps is a public API and needs no API-key
-  defaultTimeout: config.koppsApi.defaultTimeout
+  defaultTimeout: config.koppsApi.defaultTimeout,
+  retryOnESOCKETTIMEDOUT: true,
+  redis: {
+    client: config.cache.koppsApi.redis,
+    prefix: 'koppsApi',
+    expire: config.cache.koppsApi.expireTime
+  }
 })
 
 module.exports = {
@@ -17,10 +23,10 @@ module.exports = {
 }
 
 async function getKoppsCourseData (courseCode, lang = 'sv') {
-
   try {
-    return await koppsApi.getAsync(`course/${encodeURIComponent(courseCode)}/detailedinformation?l=${lang}`)
+    return await koppsApi.getAsync({uri: `course/${encodeURIComponent(courseCode)}/detailedinformation?l=${lang}`, useCache: true})
   } catch (err) {
-    return (err)
+    log.debug('Kopps is not available')
+    throw err
   }
 }

--- a/server/apiCalls/kursinfoAdmin.js
+++ b/server/apiCalls/kursinfoAdmin.js
@@ -7,14 +7,7 @@ module.exports = {
 }
 
 async function getSellingText (courseCode) {
-  const { client, paths } = api.kursinfoApiCached
+  const { client, paths } = api.kursinfoApi
   const uri = client.resolve(paths.getSellingTextByCourseCode.uri, { courseCode })
   return await client.getAsync({uri: uri, useCache: true})
 }
-
-/* async function setImage (sendObject, courseCode) {
-  const paths = api.kursinfoApi.paths
-  const client = api.kursinfoApi.client
-  const uri = client.resolve(paths.postImageInfo.uri, {courseCode: courseCode})
-  return await client.postAsync({uri: uri, body: sendObject})
-} */

--- a/server/apiCalls/kursinfoAdmin.js
+++ b/server/apiCalls/kursinfoAdmin.js
@@ -6,11 +6,10 @@ module.exports = {
   getSellingText: getSellingText
 }
 
-function getSellingText (courseCode) {
-  const paths = api.kursinfoApi.paths
-  const client = api.kursinfoApi.client
-  const uri = client.resolve(paths.getSellingTextByCourseCode.uri, { courseCode: courseCode })
-  return client.getAsync({uri: uri})
+async function getSellingText (courseCode) {
+  const { client, paths } = api.kursinfoApiCached
+  const uri = client.resolve(paths.getSellingTextByCourseCode.uri, { courseCode })
+  return await client.getAsync({uri: uri})
 }
 
 /* async function setImage (sendObject, courseCode) {

--- a/server/apiCalls/kursinfoAdmin.js
+++ b/server/apiCalls/kursinfoAdmin.js
@@ -9,7 +9,7 @@ module.exports = {
 async function getSellingText (courseCode) {
   const { client, paths } = api.kursinfoApiCached
   const uri = client.resolve(paths.getSellingTextByCourseCode.uri, { courseCode })
-  return await client.getAsync({uri: uri})
+  return await client.getAsync({uri: uri, useCache: true})
 }
 
 /* async function setImage (sendObject, courseCode) {

--- a/server/apiCalls/memoApi.js
+++ b/server/apiCalls/memoApi.js
@@ -7,9 +7,8 @@ module.exports = {
 }
 
 function _getFileList (courseCode) {
-  const paths = api.kursPMApi.paths
-  const client = api.kursPMApi.client
-  const uri = client.resolve(paths.getCourseMemoListByCourseCode.uri, { courseCode: courseCode })
-  return client.getAsync({uri: uri})
+  const { client, paths } = api.kursPMApi
+  const uri = client.resolve(paths.getCourseMemoListByCourseCode.uri, { courseCode })
+  return client.getAsync({uri: uri, useCache: true})
 }
 

--- a/server/apiCalls/memoApi.js
+++ b/server/apiCalls/memoApi.js
@@ -6,9 +6,9 @@ module.exports = {
   getFileList: _getFileList
 }
 
-function _getFileList (courseCode) {
+async function _getFileList (courseCode) {
   const { client, paths } = api.kursPMApi
   const uri = client.resolve(paths.getCourseMemoListByCourseCode.uri, { courseCode })
-  return client.getAsync({uri: uri, useCache: true})
+  return await client.getAsync({uri, useCache: true})
 }
 

--- a/server/authentication.js
+++ b/server/authentication.js
@@ -14,8 +14,7 @@ const GatewayStrategy = require('kth-node-passport-cas').GatewayStrategy
  * to Passport which implements the necessary serialization and deserialization logic. In a typical
  * application, this will be as simple as serializing the user ID, and finding the user by ID when deserializing.
  */
-passport.serializeUser(function (user, done) { console.log("user, done",user, done)
-
+passport.serializeUser(function (user, done) {
   if (user) {
     log.debug('User serialized: ' + user)
     done(null, user)
@@ -63,7 +62,7 @@ passport.use(strategy)
 
 passport.use(new GatewayStrategy({
   casUrl: config.cas.ssoBaseURL
-}, function (result, done) {console.log("ldapUser", result.user)
+}, function (result, done) {
   log.debug({ result: result }, `CAS Gateway user: ${result.user}`)
   done(null, result.user, result)
 }))

--- a/server/controllers/courseCtrl.js
+++ b/server/controllers/courseCtrl.js
@@ -168,9 +168,7 @@ async function getIndex (req, res, next) {
   }
   /** ------- CHECK OF CONNECTION TO KURS-PM-API ------- */
   let memoApiUp = true
-  log.debug(' api.kursPMApi ', api.kursPMApi)
   if (api.kursPMApi.connected && api.kursPMApi.connected === false) {
-    log.debug(' memoApiUp ', memoApiUp)
     memoApiUp = false
   }
 
@@ -206,7 +204,6 @@ async function getIndex (req, res, next) {
       }
     }
     await renderProps.props.children.props.routerStore.getCourseInformation(courseCode, ldapUser, lang)
-    log.debug('8 getCourseInformation in getIndex DONE FINAL for course code ', courseCode)
     await renderProps.props.children.props.routerStore.getCourseAdminInfo(courseCode, lang)
     log.debug('9 getCourseAdminInfo in getIndex DONE FINAL for course code ', courseCode)
     await renderProps.props.children.props.routerStore.getCourseEmployeesPost(courseCode, 'multi')
@@ -225,7 +222,6 @@ async function getIndex (req, res, next) {
       routerStore: renderProps.props.children.props.routerStore,
       routes: renderProps.props.children.props.children.props.children.props.children
     })
-
     const html = renderToString(renderProps)
 
     res.render('course/index', {


### PR DESCRIPTION
- Rebuild setup of KoppsApi
- use Async/ await
- Rebuild url for kopps
- Added use of redis cache when call apis: kurs-pm-api, kursplan-api, kopps-api, kursinfo-api

