### PR TITLE
fix(KUI-679): show round data for course with one semester

### DIFF
--- a/public/js/app/pages/CoursePage.jsx
+++ b/public/js/app/pages/CoursePage.jsx
@@ -64,8 +64,9 @@ function CoursePage() {
   } = context
 
   // * * //
+  const hasOnlyOneSemester = activeSemesters.length === 1
   const hasOnlyOneRound = activeSemester?.length > 0 && courseData.roundList[activeSemester].length === 1
-  const hasToShowRoundsData = showRoundData || (useStartSemesterFromQuery && hasOnlyOneRound)
+  const hasToShowRoundsData = showRoundData || (useStartSemesterFromQuery && hasOnlyOneRound) || hasOnlyOneSemester
 
   const hasActiveSemesters = activeSemesters && activeSemesters.length > 0
 


### PR DESCRIPTION
Enligt krav från Nina vi skulle inte visa förvald termin om kursen har bara en kull. Det kan man göra men då påverkas andra kursers visning som har flera kull. Jag har gjort lösningen så att vi visar förvald termin med tillhörande kursdata.