### PR TITLE
feat(KUI-1135): add fallback without link when SU is course department    

### DIFF
--- a/public/js/app/components/CourseSectionList.jsx
+++ b/public/js/app/components/CourseSectionList.jsx
@@ -132,7 +132,10 @@ function CourseSectionList(props) {
 
   function getOther() {
     const prepare = [
-      { header: translation.courseInformation.course_department, text: course.course_department_link },
+      {
+        header: translation.courseInformation.course_department,
+        text: course.course_department_link ?? course.course_department,
+      },
       {
         header: translation.courseInformation.course_main_subject,
         text: course.course_main_subject,

--- a/public/js/app/components/__tests__/CourseSectionList.test.js
+++ b/public/js/app/components/__tests__/CourseSectionList.test.js
@@ -107,4 +107,37 @@ describe('Component <CourseSectionList>', () => {
     syllabusText = screen.getByText(syllabusLiteratureComment, { exact: false })
     expect(syllabusText).toBeInTheDocument()
   })
+
+  test('renders course department correctly', () => {
+    const courseDepartmentLinkText = 'Link text'
+    const courseDepartmentFallbackValue = 'Fallback text'
+
+    const courseInfoWithLink = {
+      course_department_link: `<a href="/itm/" target="blank">${courseDepartmentLinkText}</a>`,
+      course_department: courseDepartmentFallbackValue,
+    }
+    const { rerender } = render(
+      <WebContextProvider configIn={{ courseInfo: courseInfoWithLink }}>
+        <CourseSectionList courseInfo={courseInfoWithLink} />
+      </WebContextProvider>
+    )
+    const linkText1 = screen.queryByText(courseDepartmentLinkText)
+    expect(linkText1).toBeInTheDocument()
+    const fallbackText1 = screen.queryByText(courseDepartmentFallbackValue)
+    expect(fallbackText1).not.toBeInTheDocument()
+
+    const courseInfoWithoutLink = {
+      course_department_link: undefined,
+      course_department: courseDepartmentFallbackValue,
+    }
+    rerender(
+      <WebContextProvider configIn={{ courseInfo: courseInfoWithoutLink }}>
+        <CourseSectionList courseInfo={courseInfoWithoutLink} />
+      </WebContextProvider>
+    )
+    const linkText2 = screen.queryByText(courseDepartmentLinkText)
+    expect(linkText2).not.toBeInTheDocument()
+    const fallbackText2 = screen.queryByText(courseDepartmentFallbackValue)
+    expect(fallbackText2).toBeInTheDocument()
+  })
 })

--- a/server/controllers/courseCtrl.js
+++ b/server/controllers/courseCtrl.js
@@ -22,6 +22,7 @@ const {
   MAX_1_MONTH,
   MAX_2_MONTH,
 } = require('../util/constants')
+const { buildCourseDepartmentLink } = require('../util/courseDepartmentUtils')
 const { formatVersionDate, getDateFormat } = require('../util/dates')
 const i18n = require('../../i18n')
 
@@ -72,14 +73,7 @@ function _parseCourseDefaultInformation(courseDetails, language) {
     course_contact_name: parceContactName(course.infoContactName, language),
     course_department: parseOrSetEmpty(course.department.name, language),
     course_department_code: parseOrSetEmpty(course.department.code, language),
-    course_department_link:
-      parseOrSetEmpty(course.department.name, language) !== INFORM_IF_IMPORTANT_INFO_IS_MISSING[language]
-        ? '<a href="/' +
-          course.department.name.split('/')[0].toLowerCase() +
-          '/" target="blank">' +
-          course.department.name +
-          '</a>'
-        : INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],
+    course_department_link: buildCourseDepartmentLink(course.department, language),
     course_disposition: parseOrSetEmpty(course.courseDeposition, language),
     course_education_type_id: course.educationalTypeId || null,
     course_examiners: INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],

--- a/server/util/__tests__/courseDepartmentUtils.test.js
+++ b/server/util/__tests__/courseDepartmentUtils.test.js
@@ -1,0 +1,36 @@
+const { buildCourseDepartmentLink } = require('../courseDepartmentUtils')
+const { INFORM_IF_IMPORTANT_INFO_IS_MISSING } = require('../constants')
+
+function htmlStringToElement(html) {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  const htmlElement = template.content.children[0]
+  return htmlElement
+}
+
+describe('course department link utils', () => {
+  test('returns department link', () => {
+    const department = { code: 'JH', name: 'EECS/Datavetenskap' }
+    const result = buildCourseDepartmentLink(department, 'en')
+    expect(result).toBeDefined()
+
+    const element = htmlStringToElement(result)
+    expect(element.href).toBe('/eecs/')
+    expect(element.innerHTML).toBe('EECS/Datavetenskap')
+  })
+
+  test('returns undefined for Stockholm university as department', () => {
+    const department = { code: 'UL', name: 'Stockholms universitet' }
+
+    const result = buildCourseDepartmentLink(department, 'en')
+    expect(result).not.toBeDefined()
+  })
+
+  test.each([undefined, { name: undefined }])('returns fallback text if department is %p', department => {
+    const resultSv = buildCourseDepartmentLink(department, 'sv')
+    expect(resultSv).toBe(INFORM_IF_IMPORTANT_INFO_IS_MISSING['sv'])
+
+    const resultEn = buildCourseDepartmentLink(department, 'en')
+    expect(resultEn).toBe(INFORM_IF_IMPORTANT_INFO_IS_MISSING['en'])
+  })
+})

--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -1,19 +1,21 @@
 const PROGRAMME_URL = '/student/kurser/program'
 const INFORM_IF_IMPORTANT_INFO_IS_MISSING = {
   en: '<i>No information inserted</i>',
-  sv: '<i>Ingen information tillagd</i>'
+  sv: '<i>Ingen information tillagd</i>',
 }
 const INFORM_IF_IMPORTANT_INFO_IS_MISSING_ABOUT_MIN_FIELD_OF_STUDY = {
   en: 'This course does not belong to any Main field of study.',
-  sv: 'Denna kurs tillhör inget huvudområde.'
+  sv: 'Denna kurs tillhör inget huvudområde.',
 }
 const MAX_1_MONTH = 3
 const MAX_2_MONTH = 9
+const DEPARTMENT_CODE_STOCKHOLM_UNIVERSITY = 'UL'
 
 module.exports = {
   PROGRAMME_URL,
   INFORM_IF_IMPORTANT_INFO_IS_MISSING,
   INFORM_IF_IMPORTANT_INFO_IS_MISSING_ABOUT_MIN_FIELD_OF_STUDY,
   MAX_1_MONTH,
-  MAX_2_MONTH
+  MAX_2_MONTH,
+  DEPARTMENT_CODE_STOCKHOLM_UNIVERSITY,
 }

--- a/server/util/courseDepartmentUtils.js
+++ b/server/util/courseDepartmentUtils.js
@@ -1,0 +1,22 @@
+const { INFORM_IF_IMPORTANT_INFO_IS_MISSING, DEPARTMENT_CODE_STOCKHOLM_UNIVERSITY } = require('./constants')
+
+function isDepartmentStockholmUniversity(courseDepartment) {
+  return courseDepartment.code === DEPARTMENT_CODE_STOCKHOLM_UNIVERSITY
+}
+
+function buildCourseDepartmentLink(courseDepartment, language) {
+  if (!courseDepartment?.name) {
+    return INFORM_IF_IMPORTANT_INFO_IS_MISSING[language]
+  }
+
+  if (isDepartmentStockholmUniversity(courseDepartment)) {
+    return undefined
+  }
+
+  const departmentLinkPart = courseDepartment.name.split('/')[0].toLowerCase()
+  return `<a href="/${departmentLinkPart}/" target="blank">${courseDepartment.name}</a>`
+}
+
+module.exports = {
+  buildCourseDepartmentLink,
+}


### PR DESCRIPTION
Today we have a broken link when Stockholm university is course department. This PR adds a fallback that only display the course department name as text when SU is course department.

JIRA: KUI-1135