### PR TITLE
fix(KUI-1222): remove postinstall hook for mini-css-extract-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "kursinfo-web",
       "version": "2.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@kth/api-call": "^4.0.40",
@@ -74,7 +73,7 @@
         "jest-environment-jsdom": "29.7.0",
         "jest-extended": "^4.0.2",
         "lint-staged": "^15.2.0",
-        "mini-css-extract-plugin": "^2.7.6",
+        "mini-css-extract-plugin": "^2.8.0",
         "nodemon": "^3.0.2",
         "null-loader": "^4.0.1",
         "path": "^0.12.7",
@@ -13296,12 +13295,13 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.6.tgz",
-      "integrity": "sha512-Qk7HcgaPkGG6eD77mLvZS1nmxlao3j+9PkrT9Uc7HAE1id3F41+DdBRYRYkbyfNRGzm8/YWtzhw7nVPmwhqTQw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.8.0.tgz",
+      "integrity": "sha512-CxmUYPFcTgET1zImteG/LZOy/4T5rTojesQXkSNBiquhydn78tfbCE9sjIjnJ/UcjNjOC1bphTCCW5rrS7cXAg==",
       "dev": true,
       "dependencies": {
-        "schema-utils": "^4.0.0"
+        "schema-utils": "^4.0.0",
+        "tapable": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.13.0"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "test:notify": "jest --watch --notify",
     "docker": "npm install --development && npm run build && npm prune --production",
     "lint": "eslint . && prettier-eslint --list-different **/*.js",
-    "postinstall": "npm run mini-css-extract-plugin && bash -c 'rm -rf ./dist; rm -rf ./node_modules/.cache/webpack'",
-    "mini-css-extract-plugin": "yarn add mini-css-extract-plugin --no-lockfile --ignore-scripts",
     "prepare": "husky install",
     "start": "bash -c 'cat /KTH_NODEJS; NODE_ENV=production node app.js'",
     "start-dev": "bash -c 'NODE_ENV=development concurrently --kill-others -n build,app \"npm run build-dev\" \"nodemon app.js\"'"
@@ -92,7 +90,7 @@
     "jest-environment-jsdom": "29.7.0",
     "jest-extended": "^4.0.2",
     "lint-staged": "^15.2.0",
-    "mini-css-extract-plugin": "^2.7.6",
+    "mini-css-extract-plugin": "^2.8.0",
     "nodemon": "^3.0.2",
     "null-loader": "^4.0.1",
     "path": "^0.12.7",


### PR DESCRIPTION
Install lastest version of mini-css-extract-plugin with npm and remove postinstall-script.