### PR TITLE
Update dependencies

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "decache": "^4.6.2",
         "eslint": "^8.57.0",
         "file-loader": "^6.2.0",
-        "husky": "^8.0.3",
+        "husky": "^9.0.11",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "29.7.0",
         "jest-extended": "^4.0.2",
@@ -9394,15 +9394,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "react": "^18.2.0",
         "react-data-table-component": "^7.6.2",
         "react-dom": "^18.2.0",
-        "react-icons": "^4.12.0",
+        "react-icons": "^5.0.1",
         "react-router": "^6.22.3",
         "react-router-dom": "^6.22.3",
         "reactstrap": "^9.2.2",
@@ -14908,9 +14908,9 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
       "peerDependencies": {
         "react": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "body-parser": "^1.20.2",
         "cookie-parser": "^1.4.6",
         "date-fns": "^2.30.0",
-        "date-fns-tz": "^2.0.0",
+        "date-fns-tz": "^2.0.1",
         "dotenv": "^16.4.5",
         "express": "^4.18.3",
         "express-handlebars": "^7.1.2",
@@ -37,8 +37,8 @@
         "react-data-table-component": "^7.6.2",
         "react-dom": "^18.2.0",
         "react-icons": "^4.12.0",
-        "react-router": "^6.22.2",
-        "react-router-dom": "^6.22.2",
+        "react-router": "^6.22.3",
+        "react-router-dom": "^6.22.3",
         "reactstrap": "^9.2.2",
         "rimraf": "^5.0.5",
         "sanitize-html": "^2.12.1",
@@ -47,7 +47,7 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
-        "@babel/cli": "^7.23.4",
+        "@babel/cli": "^7.23.9",
         "@babel/core": "^7.24.0",
         "@babel/eslint-parser": "^7.23.10",
         "@babel/plugin-transform-runtime": "^7.24.0",
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.4.tgz",
-      "integrity": "sha512-j3luA9xGKCXVyCa5R7lJvOMM+Kc2JEnAEIgz2ggtjQ/j5YUVgfsg/WsG95bbsgq7YLHuiCOzMnoSasuY16qiCw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.9.tgz",
+      "integrity": "sha512-vB1UXmGDNEhcf1jNAHKT9IlYk1R+hehVTLFlCLHBi8gfuHQGP6uRjgXVYU0EVlI/qwAWpstqkBdf2aez3/z/5Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -3610,9 +3610,9 @@
       "dev": true
     },
     "node_modules/@remix-run/router": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
-      "integrity": "sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -6856,11 +6856,11 @@
       }
     },
     "node_modules/date-fns-tz": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.0.tgz",
-      "integrity": "sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-2.0.1.tgz",
+      "integrity": "sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==",
       "peerDependencies": {
-        "date-fns": ">=2.0.0"
+        "date-fns": "2.x"
       }
     },
     "node_modules/debug": {
@@ -14936,11 +14936,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.22.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
-      "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
       "dependencies": {
-        "@remix-run/router": "1.15.2"
+        "@remix-run/router": "1.15.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14950,12 +14950,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.22.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2.tgz",
-      "integrity": "sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
       "dependencies": {
-        "@remix-run/router": "1.15.2",
-        "react-router": "6.22.2"
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "prettier-eslint-cli": "^8.0.1",
         "react-error-boundary": "^4.0.13",
         "sass": "^1.71.1",
-        "sass-loader": "^13.3.2",
+        "sass-loader": "^14.1.1",
         "set-value": "^4.1.0",
         "terser-webpack-plugin": "^5.3.10",
         "webpack": "^5.90.3",
@@ -15527,29 +15527,29 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.2.tgz",
-      "integrity": "sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-14.1.1.tgz",
+      "integrity": "sha512-QX8AasDg75monlybel38BZ49JP5Z+uSKfKwF2rO7S74BywaRmGQMUBw9dtkS+ekyM/QnP+NOrRYq8ABMZ9G8jw==",
       "dev": true,
       "dependencies": {
         "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "fibers": ">= 3.1.0",
+        "@rspack/core": "0.x || 1.x",
         "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
         "webpack": "^5.0.0"
       },
       "peerDependenciesMeta": {
-        "fibers": {
+        "@rspack/core": {
           "optional": true
         },
         "node-sass": {
@@ -15559,6 +15559,9 @@
           "optional": true
         },
         "sass-embedded": {
+          "optional": true
+        },
+        "webpack": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react": "^18.2.0",
     "react-data-table-component": "^7.6.2",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.12.0",
+    "react-icons": "^5.0.1",
     "react-router": "^6.22.3",
     "react-router-dom": "^6.22.3",
     "reactstrap": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "prettier-eslint-cli": "^8.0.1",
     "react-error-boundary": "^4.0.13",
     "sass": "^1.71.1",
-    "sass-loader": "^13.3.2",
+    "sass-loader": "^14.1.1",
     "set-value": "^4.1.0",
     "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.90.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "body-parser": "^1.20.2",
     "cookie-parser": "^1.4.6",
     "date-fns": "^2.30.0",
-    "date-fns-tz": "^2.0.0",
+    "date-fns-tz": "^2.0.1",
     "dotenv": "^16.4.5",
     "express": "^4.18.3",
     "express-handlebars": "^7.1.2",
@@ -54,8 +54,8 @@
     "react-data-table-component": "^7.6.2",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",
-    "react-router": "^6.22.2",
-    "react-router-dom": "^6.22.2",
+    "react-router": "^6.22.3",
+    "react-router-dom": "^6.22.3",
     "reactstrap": "^9.2.2",
     "rimraf": "^5.0.5",
     "sanitize-html": "^2.12.1",
@@ -64,7 +64,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
-    "@babel/cli": "^7.23.4",
+    "@babel/cli": "^7.23.9",
     "@babel/core": "^7.24.0",
     "@babel/eslint-parser": "^7.23.10",
     "@babel/plugin-transform-runtime": "^7.24.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:notify": "jest --watch --notify",
     "docker": "npm install --development && npm run build && npm prune --production",
     "lint": "eslint . && prettier-eslint --list-different **/*.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "start": "bash -c 'cat /KTH_NODEJS; NODE_ENV=production node app.js'",
     "start-dev": "bash -c 'NODE_ENV=development concurrently --kill-others -n build,app \"npm run build-dev\" \"nodemon app.js\"'"
   },
@@ -85,7 +85,7 @@
     "decache": "^4.6.2",
     "eslint": "^8.57.0",
     "file-loader": "^6.2.0",
-    "husky": "^8.0.3",
+    "husky": "^9.0.11",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "jest-extended": "^4.0.2",


### PR DESCRIPTION
This PR is updating minor/patch updates as well as a couple of major updates.

The following dependencies are left unchanged.

- `date-fns`, because `date-fns-tz` is not compatible with it yet (see https://github.com/marnusw/date-fns-tz/issues/260) 
- `prettier-2` only exists as a temporary workaround and will not be needed anymore as soon as `jest@30` is released. (see https://github.com/jestjs/jest/issues/14305) 

```
 date-fns            ^2.30.0  →  ^3.4.0
 prettier-2  npm:prettier@^2  →      ^3
```