### PR TITLE
fix(KUI-1176): Bugfixes

### DIFF
--- a/server/controllers/__tests__/courseCtrlHelpers.test.js
+++ b/server/controllers/__tests__/courseCtrlHelpers.test.js
@@ -90,8 +90,8 @@ describe('courseCtrlHelpers', () => {
         })
 
         test.each([
-          ['2022-09-04', 20231],
-          ['2023-03-04', 20232],
+          ['2022-10-20', 20231],
+          ['2023-04-22', 20232],
           ['2023-12-30', 20241],
           ['2024-07-04', 20242],
         ])('should match the date %s to the active semester %s', (currentDate, expectedTerm) => {
@@ -129,26 +129,54 @@ describe('courseCtrlHelpers', () => {
   })
 
   describe('generateSemesterBasedOnDate', () => {
-    test('January through February result in period 1 of the same year', () => {
+    test('January through March result in period 1 of the same year', () => {
       const expectedSemester = '20241'
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-01-01'))).toBe(expectedSemester)
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-02-29'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-03-01'))).toBe(expectedSemester)
     })
 
-    test('March through August result in period 2 of the same year', () => {
+    test('April 1st through April 19th result in period 1 of the same year', () => {
+      const expectedSemester = '20241'
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-04-01'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-04-10'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-04-19'))).toBe(expectedSemester)
+    })
+
+    test('April 20th through April 30th result in period 2 of the same year', () => {
       const expectedSemester = '20242'
-      expect(generateSelectedSemesterBasedOnDate(new Date('2024-03-01'))).toBe(expectedSemester)
-      expect(generateSelectedSemesterBasedOnDate(new Date('2024-04-29'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-04-20'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-04-25'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-04-30'))).toBe(expectedSemester)
+    })
+
+    test('May through September result in period 2 of the same year', () => {
+      const expectedSemester = '20242'
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-05-01'))).toBe(expectedSemester)
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-05-29'))).toBe(expectedSemester)
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-06-29'))).toBe(expectedSemester)
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-07-29'))).toBe(expectedSemester)
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-08-29'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-09-01'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-09-30'))).toBe(expectedSemester)
     })
 
-    test('September through december result in period 1 of the next year', () => {
-      const expectedSemester = '20251'
-      expect(generateSelectedSemesterBasedOnDate(new Date('2024-09-01'))).toBe(expectedSemester)
+    test('October 1st through October 19th result in period 1 of the same year', () => {
+      const expectedSemester = '20242'
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-10-01'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-10-10'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-10-19'))).toBe(expectedSemester)
+    })
+
+    test('October 20th through October 30th result in period 1 of the next year', () => {
+      const expectedSemester = '20251'
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-10-20'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-10-25'))).toBe(expectedSemester)
+      expect(generateSelectedSemesterBasedOnDate(new Date('2024-10-30'))).toBe(expectedSemester)
+    })
+
+    test('November through December result in period 1 of the next year', () => {
+      const expectedSemester = '20251'
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-11-01'))).toBe(expectedSemester)
       expect(generateSelectedSemesterBasedOnDate(new Date('2024-12-01'))).toBe(expectedSemester)
     })

--- a/server/controllers/__tests__/createSyllabusList.test.js
+++ b/server/controllers/__tests__/createSyllabusList.test.js
@@ -242,12 +242,21 @@ const formattedGradeScales = {
 }
 
 describe('createSyllabusList', () => {
-  test('exists', () => {
+  test('creates syllabus list', () => {
     const { syllabusList } = createSyllabusList(
       { publicSyllabusVersions: syllabuses, course, examinationSets, formattedGradeScales },
       'en'
     )
 
     expect(syllabusList).toEqual(expectedSyllabusList)
+  })
+
+  test('if empty publicSyllabusVersions, returns empty array', () => {
+    const { syllabusList } = createSyllabusList(
+      { publicSyllabusVersions: [], course, examinationSets, formattedGradeScales },
+      'en'
+    )
+
+    expect(syllabusList).toEqual([])
   })
 })

--- a/server/controllers/courseCtrlHelpers.js
+++ b/server/controllers/courseCtrlHelpers.js
@@ -1,32 +1,32 @@
+const { isBefore } = require('date-fns')
 const { INFORM_IF_IMPORTANT_INFO_IS_MISSING } = require('../util/constants')
-const { convertYearSemesterNumberIntoSemester } = require('../util/semesterUtils')
+const { convertYearSemesterNumberIntoSemester, SEMESTER_NUMBER } = require('../util/semesterUtils')
+
+const DATE_OF_MONTH_ON_WHICH_TO_SWITCH_TO_NEXT_SEMESTER = 20
+const SPRING_BREAK_MONTH = 4
+const AUTUMN_BREAK_MONTH = 10
+
+const createSpringBreakDateForYear = year =>
+  new Date(`${year}-${SPRING_BREAK_MONTH}-${DATE_OF_MONTH_ON_WHICH_TO_SWITCH_TO_NEXT_SEMESTER}`)
+const createAutumnBreakDateForYear = year =>
+  new Date(`${year}-${AUTUMN_BREAK_MONTH}-${DATE_OF_MONTH_ON_WHICH_TO_SWITCH_TO_NEXT_SEMESTER}`)
 
 /**
  * Generates a semester-string based on the current year and month.
  * E.g. if its May 2024, the semester string would be `20242`
  *
  */
-function generateSelectedSemesterBasedOnDate(thisDate) {
-  const currentYear = thisDate.getFullYear()
-  switch (thisDate.getMonth()) {
-    case 0: // January
-    case 1: // February
-      return `${currentYear}1`
-    case 2: // March
-    case 3:
-    case 4:
-    case 5:
-    case 6:
-    case 7: // August
-      return `${currentYear}2`
-    case 8: // September
-    case 9:
-    case 10:
-    case 11: // December
-      return `${currentYear + 1}1`
-    default:
-      return ''
-  }
+function generateSelectedSemesterBasedOnDate(date) {
+  const year = date.getFullYear()
+
+  const springBreakDate = createSpringBreakDateForYear(year)
+  const autumnBreakDate = createAutumnBreakDateForYear(year)
+
+  if (isBefore(date, springBreakDate)) return `${year}${SEMESTER_NUMBER.SPRING}`
+
+  if (isBefore(date, autumnBreakDate)) return `${year}${SEMESTER_NUMBER.AUTUMN}`
+
+  return `${year + 1}${SEMESTER_NUMBER.SPRING}`
 }
 
 const semesterExistsInArray = (needle, haystack) => haystack.some(({ semester }) => semester === needle)

--- a/server/controllers/createSyllabusList.js
+++ b/server/controllers/createSyllabusList.js
@@ -104,7 +104,7 @@ const createSyllabusList = (courseDetails, lang) => {
 
   if (publicSyllabusVersions.length === 0) {
     return {
-      syllabusList: [_createEmptySyllabusData()],
+      syllabusList: [],
     }
   }
 

--- a/server/util/semesterUtils.js
+++ b/server/util/semesterUtils.js
@@ -7,6 +7,11 @@
  *
  */
 
+const SEMESTER_NUMBER = {
+  SPRING: 1,
+  AUTUMN: 2,
+}
+
 /**
  * Takes a yearSemesterNumber and returns a yearSemesterNumber representing the semester previous to the given semester
  *
@@ -86,4 +91,5 @@ module.exports = {
   parseSemesterIntoYearSemesterNumber,
   convertYearSemesterNumberIntoSemester,
   convertToYearSemesterNumberOrGetCurrent,
+  SEMESTER_NUMBER,
 }


### PR DESCRIPTION
This PR

- fixes a bug that added an empty syllabus to `syllabusList` when we get an empty syllabusList from kopps
- calculates the `initiallySelectedSemester` based on new specs