### PR TITLE
fix(KUI-1196): add orderedSchoolsOptions to have charts in alphabetical order

### DIFF
--- a/public/js/app/components/statistics/Chart.jsx
+++ b/public/js/app/components/statistics/Chart.jsx
@@ -32,7 +32,7 @@ function splitIntoLines(label) {
 }
 
 function getChartData(numberName, schools, allSchoolsLabels) {
-  const orderedSchools = schoolsLib.orderedSchoolsFormOptions()
+  const orderedSchools = schoolsLib.orderedSchoolsOptions()
 
   let schoolCodes = Object.keys(schools)
 

--- a/public/js/app/components/statistics/domain/schools.js
+++ b/public/js/app/components/statistics/domain/schools.js
@@ -9,6 +9,7 @@ const ORDERED_SCHOOLS_FORM = [SCHOOLS.ABE, SCHOOLS.ITM, SCHOOLS.CBH, SCHOOLS.SCI
 const ORDERED_SCHOOLS = [SCHOOLS.ABE, SCHOOLS.CBH, SCHOOLS.EECS, SCHOOLS.ITM, SCHOOLS.SCI]
 
 const orderedSchoolsFormOptions = () => [...ORDERED_SCHOOLS_FORM, 'allSchools']
+const orderedSchoolsOptions = () => [...ORDERED_SCHOOLS, 'allSchools']
 const DEPARTMENT_TO_SCHOOL_MAP = {
   ABE: SCHOOLS.ABE,
   CBH: SCHOOLS.CBH,
@@ -23,4 +24,4 @@ const DEPARTMENT_TO_SCHOOL_MAP = {
   ITM: SCHOOLS.ITM,
   SCI: SCHOOLS.SCI,
 }
-export default { DEPARTMENT_TO_SCHOOL_MAP, ORDERED_SCHOOLS, orderedSchoolsFormOptions, SCHOOLS }
+export default { DEPARTMENT_TO_SCHOOL_MAP, ORDERED_SCHOOLS, orderedSchoolsFormOptions, orderedSchoolsOptions, SCHOOLS }


### PR DESCRIPTION
https://kth-se.atlassian.net/browse/KUI-1196?focusedCommentId=17900 based on this comment by Nina we have made the required changes to have the charts in alphabetical order.