### PR TITLE
Chore/upgrade/kth cortina block 7

### DIFF
--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -69,7 +69,6 @@ module.exports = {
       studentSearch: '1.1066521',
       studentFooter: '1.1066523',
     },
-    globalLink: false,
   },
 
   // Logging

--- a/config/serverSettings.js
+++ b/config/serverSettings.js
@@ -64,7 +64,6 @@ module.exports = {
   blockApi: {
     blockUrl: getEnv('CM_HOST_URL', devDefaults('https://www-r.referens.sys.kth.se/cm/')), // Block API base URL
     addBlocks: {
-      secondaryMenu: '1.1066515',
       studentMegaMenu: '1.1066510',
       studentSearch: '1.1066521',
       studentFooter: '1.1066523',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@kth/api-call": "^4.1.0",
         "@kth/appinsights": "^0.4.0",
+        "@kth/cortina-block": "^7.0.0",
         "@kth/kth-node-response": "^1.0.7",
         "@kth/kth-node-web-common": "^9.3.1",
         "@kth/log": "^4.0.7",
@@ -3445,16 +3446,15 @@
       }
     },
     "node_modules/@kth/cortina-block": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@kth/cortina-block/-/cortina-block-5.1.1.tgz",
-      "integrity": "sha512-ljLownpz7rPvkb5lamNaAhKKpwfmoQ30l4MJvT3E1Sq4wJvmVyi6oQCOlyWbKT6v91Fbkb9BM2E4nDFrzShVRg==",
-      "license": "MIT",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@kth/cortina-block/-/cortina-block-7.0.0.tgz",
+      "integrity": "sha512-AiVj3Tj6eTTTdAsq0UACnqe59BuWGIaOmLsBDmjYbuvWKehVYc38QQsgSpqeGSsUPagW83XrqLlyNQ7q3o4O9A==",
       "dependencies": {
         "@kth/log": "^4.0.7",
-        "cheerio": "^1.0.0-rc.12"
+        "kth-node-redis": "^3.3.0"
       },
-      "peerDependencies": {
-        "@kth/log": "^4.0.5"
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@kth/eslint-config-kth": {
@@ -3497,6 +3497,18 @@
         "kth-node-i18n": "^1.0.18",
         "kth-node-redis": "^3.3.0",
         "locale": "^0.1.0"
+      }
+    },
+    "node_modules/@kth/kth-node-web-common/node_modules/@kth/cortina-block": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@kth/cortina-block/-/cortina-block-5.1.1.tgz",
+      "integrity": "sha512-ljLownpz7rPvkb5lamNaAhKKpwfmoQ30l4MJvT3E1Sq4wJvmVyi6oQCOlyWbKT6v91Fbkb9BM2E4nDFrzShVRg==",
+      "dependencies": {
+        "@kth/log": "^4.0.7",
+        "cheerio": "^1.0.0-rc.12"
+      },
+      "peerDependencies": {
+        "@kth/log": "^4.0.5"
       }
     },
     "node_modules/@kth/log": {
@@ -6028,8 +6040,7 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC"
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/boolify": {
       "version": "1.0.1",
@@ -6323,21 +6334,24 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "license": "MIT",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18.17"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -6347,7 +6361,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-select": "^5.1.0",
@@ -6358,6 +6371,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/cheerio/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -7126,7 +7176,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
       "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.1.0",
@@ -7154,7 +7203,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -7901,6 +7949,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
+      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -14463,7 +14545,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -14825,12 +14906,22 @@
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "license": "MIT",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "dependencies": {
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -17790,6 +17881,14 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@kth/api-call": "^4.1.0",
     "@kth/appinsights": "^0.4.0",
+    "@kth/cortina-block": "^7.0.0",
     "@kth/kth-node-response": "^1.0.7",
     "@kth/kth-node-web-common": "^9.3.1",
     "@kth/log": "^4.0.7",

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ const config = require('./configuration').server
 require('./api')
 const AppRouter = require('kth-node-express-routing').PageRouter
 const { getPaths } = require('kth-node-express-routing')
+const { cortinaMiddleware } = require('@kth/cortina-block')
 
 // Expose the server and paths
 server.locals.secret = new Map()
@@ -134,13 +135,13 @@ server.use(config.proxyPrefixPath.uri, languageHandler)
  */
 server.use(
   config.proxyPrefixPath.uri,
-  require('@kth/kth-node-web-common/lib/web/cortina')({
-    blockUrl: config.blockApi.blockUrl,
+  cortinaMiddleware({
+    blockApiUrl: config.blockApi.blockUrl,
     proxyPrefixPath: config.proxyPrefixPath.uri,
     hostUrl: config.hostUrl,
     redisConfig: config.cache.cortinaBlock.redis,
     globalLink: config.blockApi.globalLink,
-    addBlocks: config.blockApi.addBlocks,
+    blocksConfig: config.blockApi.addBlocks,
     redisKey: config.cache.cortinaBlock.redisKey,
     useStyle10: true,
     // globalLink: true ---> don't use it, because we use local site language link, not global kth link

--- a/server/server.js
+++ b/server/server.js
@@ -137,14 +137,9 @@ server.use(
   config.proxyPrefixPath.uri,
   cortinaMiddleware({
     blockApiUrl: config.blockApi.blockUrl,
-    proxyPrefixPath: config.proxyPrefixPath.uri,
-    hostUrl: config.hostUrl,
     redisConfig: config.cache.cortinaBlock.redis,
-    globalLink: config.blockApi.globalLink,
     blocksConfig: config.blockApi.addBlocks,
     redisKey: config.cache.cortinaBlock.redisKey,
-    useStyle10: true,
-    // globalLink: true ---> don't use it, because we use local site language link, not global kth link
   })
 )
 


### PR DESCRIPTION
Hi.
We have made a lot of changes to the package that fetches `blocks` from cortina.
It has been a chaotic journey, but now we have somewhat of a "finished" version.


Before, we had the middleware in one package and most of the logic in another, now everything is in [@kth/cortina-block](https://www.npmjs.com/package/@kth/cortina-block).

A lot of its old settings is no longer used since we changed all apps to Style 10 last spring.


I made this PR as an example for you, and to test if it works well with your apps.
This should be the most demanding one, since it uses a few student-specific blocks.


(Have not been able to do a full test since I lack all settings on localhost, but I can see the studentMegaMenu render)
