### PR TITLE
KUI-1467 CourseRound dropdown suffix solely based on funding type

### DIFF
--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -203,16 +203,12 @@ module.exports = {
     },
     round_time_slots: 'Planned modular schedule',
     round_application_link: 'Go to the registration',
-    round_category: {
-      PU: 'programme students',
-      VU: 'single courses students',
-      pu_and_vu: 'programme and single courses students',
-    },
-    round_type: {
+    round_type_suffix: {
       ORD: 'programme students',
       UPP: 'contract education',
       PER: 'course for KTH staff',
       SAP: 'Study Abroad Programme',
+      VU: 'single courses students',
     },
   },
   courseMainSubjects: {

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -213,16 +213,12 @@ module.exports = {
     },
     round_time_slots: 'Planerade schemamoduler',
     round_application_link: 'Till anmälan',
-    round_category: {
-      PU: 'programstuderande',
-      VU: 'fristående studerande',
-      pu_and_vu: 'programstuderande och fristående studerande',
-    },
-    round_type: {
+    round_type_suffix: {
       ORD: 'programstuderande',
       UPP: 'uppdragsutbildning',
       PER: 'kurser för KTHs personal',
       SAP: 'Study Abroad Programme',
+      VU: 'fristående studerande',
     },
   },
   courseImage: {

--- a/public/js/app/hooks/__tests__/useRoundUtils.test.js
+++ b/public/js/app/hooks/__tests__/useRoundUtils.test.js
@@ -6,21 +6,51 @@ import translationEn from '../../../../../i18n/messages.en'
 
 jest.mock('../useLanguage')
 
-const POSSIBLE_ROUND_CATEGORIES = {
-  PU: { round_category: 'PU', sv: 'programstuderande', en: 'programme students' },
-  VU: { round_category: 'VU', sv: 'fristående studerande', en: 'single courses students' },
-  PU_AND_VU: {
-    round_category: 'pu_and_vu',
-    sv: 'programstuderande och fristående studerande',
-    en: 'programme and single courses students',
-  },
-}
+const FUNDING_TYPES_SWEDISH = [
+  ['UPP', 'uppdragsutbildning'],
+  ['IND', 'programstuderande'],
+  ['EXA', 'programstuderande'],
+  ['SÖ', 'programstuderande'],
+  ['LHS', 'programstuderande'],
+  ['PER', 'kurser för KTHs personal'],
+  ['ORD', 'programstuderande'],
+  ['B', 'programstuderande'],
+  ['FOR', 'programstuderande'],
+  ['GYM', 'programstuderande'],
+  ['EIS', 'programstuderande'],
+  ['SU', 'programstuderande'],
+  ['BDR', 'programstuderande'],
+  ['UFH', 'programstuderande'],
+  ['KPL', 'programstuderande'],
+  ['UPS', 'programstuderande'],
+  ['SAP', 'Study Abroad Programme'],
+  ['FOA', 'fristående studerande'],
+  ['MH', 'fristående studerande'],
+  ['LL', 'fristående studerande'],
+]
 
-const FUNDING_TYPES_WITH_SPECIAL_HANDLING = {
-  PER: { round_funding_type: 'PER', sv: 'kurser för KTHs personal', en: 'course for KTH staff' },
-  UPP: { round_funding_type: 'UPP', sv: 'uppdragsutbildning', en: 'contract education' },
-  SAP: { round_funding_type: 'SAP', sv: 'Study Abroad Programme', en: 'Study Abroad Programme' },
-}
+const FUNDING_TYPES_ENGLISH = [
+  ['UPP', 'contract education'],
+  ['IND', 'programme students'],
+  ['EXA', 'programme students'],
+  ['SÖ', 'programme students'],
+  ['LHS', 'programme students'],
+  ['PER', 'course for KTH staff'],
+  ['ORD', 'programme students'],
+  ['B', 'programme students'],
+  ['FOR', 'programme students'],
+  ['GYM', 'programme students'],
+  ['EIS', 'programme students'],
+  ['SU', 'programme students'],
+  ['BDR', 'programme students'],
+  ['UFH', 'programme students'],
+  ['KPL', 'programme students'],
+  ['UPS', 'programme students'],
+  ['SAP', 'Study Abroad Programme'],
+  ['FOA', 'single courses students'],
+  ['MH', 'single courses students'],
+  ['LL', 'single courses students'],
+]
 
 describe('useRoundUtils', () => {
   describe('swedish', () => {
@@ -31,52 +61,25 @@ describe('useRoundUtils', () => {
       })
     })
 
-    test.each([
-      FUNDING_TYPES_WITH_SPECIAL_HANDLING.PER,
-      FUNDING_TYPES_WITH_SPECIAL_HANDLING.UPP,
-      FUNDING_TYPES_WITH_SPECIAL_HANDLING.SAP,
-    ])('handles special case regardless of round category', ({ round_funding_type, sv }) => {
-      const { result } = renderHook(() => useRoundUtils())
-
-      expect(
-        result.current.createRoundLabel({
-          round_short_name: 'someShortName',
-          round_category: POSSIBLE_ROUND_CATEGORIES.PU,
-          round_funding_type,
-        })
-      ).toStrictEqual(`someShortName ${sv}`)
-
-      expect(
-        result.current.createRoundHeader({
-          round_short_name: 'someShortName',
-          round_category: POSSIBLE_ROUND_CATEGORIES.VU,
-          round_funding_type,
-          round_course_term: ['2024', '2'],
-        })
-      ).toStrictEqual(`HT 2024 someShortName ${sv}`)
-    })
-
-    test.each([POSSIBLE_ROUND_CATEGORIES.PU, POSSIBLE_ROUND_CATEGORIES.VU, POSSIBLE_ROUND_CATEGORIES.PU_AND_VU])(
-      'handles default case, displaying round category',
-      ({ round_category, sv }) => {
+    test.each(FUNDING_TYPES_SWEDISH)(
+      'for funding type "%s", displays correct suffix "%s"',
+      (round_funding_type, expectedSuffix) => {
         const { result } = renderHook(() => useRoundUtils())
 
         expect(
           result.current.createRoundLabel({
             round_short_name: 'someShortName',
-            round_category,
-            round_funding_type: 'someNonSpecialFundingType',
+            round_funding_type,
           })
-        ).toStrictEqual(`someShortName ${sv}`)
+        ).toStrictEqual(`someShortName ${expectedSuffix}`)
 
         expect(
           result.current.createRoundHeader({
             round_short_name: 'someShortName',
-            round_category,
-            round_funding_type: 'someNonSpecialFundingType',
+            round_funding_type,
             round_course_term: ['2024', '2'],
           })
-        ).toStrictEqual(`HT 2024 someShortName ${sv}`)
+        ).toStrictEqual(`HT 2024 someShortName ${expectedSuffix}`)
       }
     )
 
@@ -90,13 +93,10 @@ describe('useRoundUtils', () => {
       expect(
         result.current.createRoundHeader({
           round_short_name: 'someShortName',
-          round_category: POSSIBLE_ROUND_CATEGORIES.PU.round_category,
-          round_funding_type: 'someNonSpecialFundingType',
+          round_funding_type: 'LL',
           round_course_term,
         })
-      ).toStrictEqual(
-        `${expectedSemesterString} ${round_course_term[0]} someShortName ${POSSIBLE_ROUND_CATEGORIES.PU.sv}`
-      )
+      ).toStrictEqual(`${expectedSemesterString} ${round_course_term[0]} someShortName fristående studerande`)
     })
   })
 
@@ -108,52 +108,25 @@ describe('useRoundUtils', () => {
       })
     })
 
-    test.each([
-      FUNDING_TYPES_WITH_SPECIAL_HANDLING.PER,
-      FUNDING_TYPES_WITH_SPECIAL_HANDLING.UPP,
-      FUNDING_TYPES_WITH_SPECIAL_HANDLING.SAP,
-    ])('handles special case regardless of round category', ({ round_funding_type, en }) => {
-      const { result } = renderHook(() => useRoundUtils())
-
-      expect(
-        result.current.createRoundLabel({
-          round_short_name: 'someShortName',
-          round_category: POSSIBLE_ROUND_CATEGORIES.PU,
-          round_funding_type,
-        })
-      ).toStrictEqual(`someShortName ${en}`)
-
-      expect(
-        result.current.createRoundHeader({
-          round_short_name: 'someShortName',
-          round_category: POSSIBLE_ROUND_CATEGORIES.VU,
-          round_funding_type,
-          round_course_term: ['2024', '2'],
-        })
-      ).toStrictEqual(`Autumn 2024 someShortName ${en}`)
-    })
-
-    test.each([POSSIBLE_ROUND_CATEGORIES.PU, POSSIBLE_ROUND_CATEGORIES.VU, POSSIBLE_ROUND_CATEGORIES.PU_AND_VU])(
-      'handles default case, displaying round category',
-      ({ round_category, en }) => {
+    test.each(FUNDING_TYPES_ENGLISH)(
+      'for funding type "%s", displays correct suffix "%s"',
+      (round_funding_type, expectedSuffix) => {
         const { result } = renderHook(() => useRoundUtils())
 
         expect(
           result.current.createRoundLabel({
             round_short_name: 'someShortName',
-            round_category,
-            round_funding_type: 'someNonSpecialFundingType',
+            round_funding_type,
           })
-        ).toStrictEqual(`someShortName ${en}`)
+        ).toStrictEqual(`someShortName ${expectedSuffix}`)
 
         expect(
           result.current.createRoundHeader({
             round_short_name: 'someShortName',
-            round_category,
-            round_funding_type: 'someNonSpecialFundingType',
+            round_funding_type,
             round_course_term: ['2024', '2'],
           })
-        ).toStrictEqual(`Autumn 2024 someShortName ${en}`)
+        ).toStrictEqual(`Autumn 2024 someShortName ${expectedSuffix}`)
       }
     )
 
@@ -167,13 +140,10 @@ describe('useRoundUtils', () => {
       expect(
         result.current.createRoundHeader({
           round_short_name: 'someShortName',
-          round_category: POSSIBLE_ROUND_CATEGORIES.PU.round_category,
-          round_funding_type: 'someNonSpecialFundingType',
+          round_funding_type: 'LL',
           round_course_term,
         })
-      ).toStrictEqual(
-        `${expectedSemesterString} ${round_course_term[0]} someShortName ${POSSIBLE_ROUND_CATEGORIES.PU.en}`
-      )
+      ).toStrictEqual(`${expectedSemesterString} ${round_course_term[0]} someShortName single courses students`)
     })
   })
 })

--- a/public/js/app/hooks/__tests__/useSemesterRoundState.test.js
+++ b/public/js/app/hooks/__tests__/useSemesterRoundState.test.js
@@ -25,7 +25,6 @@ const roundsBySemester = {
         '<p>\n          <a href="/student/kurser/program/CSAMH/20232/arskurs1">\n            Degree Programme in Civil Engineering and Urban Management, åk 1, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CTKEM/20232/arskurs1">\n            Degree Programme in Engineering Chemistry, åk 1, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CMATD/20232/arskurs1">\n            Degree Programme in Materials Design and Engineering, åk 1, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CLGYM/20222/arskurs2#inrMAKE">\n            Master of Science in Engineering and in Education, åk 2, MAKE, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CLGYM/20222/arskurs2#inrTEDA">\n            Master of Science in Engineering and in Education, åk 2, TEDA, Mandatory\n        </a>\n      </p>',
       round_state: 'APPROVED',
       round_comment: '',
-      round_category: 'PU',
     },
   ],
   20232: [
@@ -54,7 +53,6 @@ const roundsBySemester = {
         '<p>\n          <a href="/student/kurser/program/CSAMH/20232/arskurs1">\n            Degree Programme in Civil Engineering and Urban Management, åk 1, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CTKEM/20232/arskurs1">\n            Degree Programme in Engineering Chemistry, åk 1, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CMATD/20232/arskurs1">\n            Degree Programme in Materials Design and Engineering, åk 1, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CLGYM/20222/arskurs2#inrMAKE">\n            Master of Science in Engineering and in Education, åk 2, MAKE, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CLGYM/20222/arskurs2#inrTEDA">\n            Master of Science in Engineering and in Education, åk 2, TEDA, Mandatory\n        </a>\n      </p>',
       round_state: 'APPROVED',
       round_comment: '',
-      round_category: 'PU',
     },
     {
       round_time_slots: '<i>No information inserted</i>',
@@ -81,7 +79,6 @@ const roundsBySemester = {
         '<p>\n          <a href="/student/kurser/program/CDATE/20232/arskurs1">\n            Degree Programme in Computer Science and Engineering, åk 1, Mandatory\n        </a>\n      </p>',
       round_state: 'APPROVED',
       round_comment: '',
-      round_category: 'PU',
     },
   ],
   20242: [
@@ -110,7 +107,6 @@ const roundsBySemester = {
         '<p>\n          <a href="/student/kurser/program/COPEN/20242/arskurs1">\n            Degree Programme Open Entrance, åk 1, Mandatory\n        </a>\n      </p><p>\n          <a href="/student/kurser/program/CMETE/20242/arskurs1">\n            Degree Programme in Media Technology, åk 1, Mandatory\n        </a>\n      </p>',
       round_state: 'APPROVED',
       round_comment: '',
-      round_category: 'PU',
     },
     {
       round_time_slots: '<i>No information inserted</i>',
@@ -137,7 +133,6 @@ const roundsBySemester = {
         '<p>\n          <a href="/student/kurser/program/CINTE/20242/arskurs1">\n            Degree Programme in Information and Communication Technology, åk 1, Mandatory\n        </a>\n      </p>',
       round_state: 'APPROVED',
       round_comment: '',
-      round_category: 'PU',
     },
   ],
 }

--- a/public/js/app/hooks/__tests__/useSemesterRoundState.test.js
+++ b/public/js/app/hooks/__tests__/useSemesterRoundState.test.js
@@ -18,7 +18,6 @@ const roundsBySemester = {
       round_periods: 'P2 (7.5 hp)',
       round_seats: '',
       round_selection_criteria: '<p></p>',
-      round_type: 'Programutbildning',
       round_funding_type: 'ORD',
       round_application_link: '<i>No information inserted</i>',
       round_part_of_programme:
@@ -46,7 +45,6 @@ const roundsBySemester = {
       round_periods: 'P2 (7.5 hp)',
       round_seats: '',
       round_selection_criteria: '<p></p>',
-      round_type: 'Programutbildning',
       round_funding_type: 'ORD',
       round_application_link: '<i>No information inserted</i>',
       round_part_of_programme:
@@ -72,7 +70,6 @@ const roundsBySemester = {
       round_periods: 'P2 (7.5 hp)',
       round_seats: '',
       round_selection_criteria: '<p></p>',
-      round_type: 'Programutbildning',
       round_funding_type: 'ORD',
       round_application_link: '<i>No information inserted</i>',
       round_part_of_programme:
@@ -100,7 +97,6 @@ const roundsBySemester = {
       round_periods: 'P2 (7.5 hp)',
       round_seats: '',
       round_selection_criteria: '<p></p>',
-      round_type: 'Programutbildning',
       round_funding_type: 'ORD',
       round_application_link: '<i>No information inserted</i>',
       round_part_of_programme:
@@ -126,7 +122,6 @@ const roundsBySemester = {
       round_periods: 'P2 (7.5 hp)',
       round_seats: '',
       round_selection_criteria: '<p></p>',
-      round_type: 'Programutbildning',
       round_funding_type: 'ORD',
       round_application_link: '<i>No information inserted</i>',
       round_part_of_programme:

--- a/public/js/app/hooks/useRoundUtils.js
+++ b/public/js/app/hooks/useRoundUtils.js
@@ -2,28 +2,51 @@ import React from 'react'
 import { useLanguage } from './useLanguage'
 import { useMissingInfo } from './useMissingInfo'
 
+// Matches fundingType to roundType key that holds the suffix we want to display
+const FUNDING_TYPE_TO_ROUND_TYPE_SUFFIX_MAPPING = {
+  UPP: 'UPP',
+  PER: 'PER',
+  SAP: 'SAP',
+  ORD: 'ORD',
+  IND: 'ORD',
+  EXA: 'ORD',
+  SÖ: 'ORD',
+  LHS: 'ORD',
+  B: 'ORD',
+  FOR: 'ORD',
+  GYM: 'ORD',
+  EIS: 'ORD',
+  SU: 'ORD',
+  BDR: 'ORD',
+  UFH: 'ORD',
+  KPL: 'ORD',
+  UPS: 'ORD',
+  FOA: 'VU',
+  MH: 'VU',
+  LL: 'VU',
+}
+
+const getRoundType = roundFundingType => FUNDING_TYPE_TO_ROUND_TYPE_SUFFIX_MAPPING[roundFundingType]
+
 export const useRoundUtils = () => {
   const { translation } = useLanguage()
   const { isMissingInfoLabel } = useMissingInfo()
 
   const createRoundLabel = React.useMemo(
     () =>
-      ({ round_short_name, round_funding_type, round_category }) => {
-        let fundingType
-        if (round_funding_type === 'PER' || round_funding_type === 'UPP' || round_funding_type === 'SAP') {
-          fundingType = translation.courseRoundInformation.round_type[round_funding_type]
-        } else {
-          fundingType = translation.courseRoundInformation.round_category[round_category]
-        }
-        return `${!isMissingInfoLabel(round_short_name) ? `${round_short_name}` : ''} ${fundingType}`
+      ({ round_short_name, round_funding_type }) => {
+        const roundTypeKey = getRoundType(round_funding_type)
+        const roundTypeSuffix = translation.courseRoundInformation.round_type_suffix[roundTypeKey]
+
+        return `${!isMissingInfoLabel(round_short_name) ? `${round_short_name}` : ''} ${roundTypeSuffix}`
       },
     [translation, isMissingInfoLabel]
   )
 
   const createRoundHeader = React.useMemo(
     () =>
-      ({ round_short_name, round_funding_type, round_category, round_course_term }) => {
-        const roundLabel = createRoundLabel({ round_short_name, round_funding_type, round_category })
+      ({ round_short_name, round_funding_type, round_course_term }) => {
+        const roundLabel = createRoundLabel({ round_short_name, round_funding_type })
 
         const [roundYear, roundPeriod] = round_course_term
         const semesterStringOrEmpty = translation.courseInformation.course_short_semester[roundPeriod] ?? ''

--- a/public/js/app/pages/__tests__/CoursePage.test.js
+++ b/public/js/app/pages/__tests__/CoursePage.test.js
@@ -62,7 +62,6 @@ describe('Component <CoursePage>', () => {
             round_tutoring_form: 'NML',
             round_tutoring_language: 'Swedish',
             round_tutoring_time: 'DAG',
-            round_type: 'Programutbildning',
           },
           {
             has_round_published_memo: true,
@@ -89,7 +88,6 @@ describe('Component <CoursePage>', () => {
             round_tutoring_form: 'NML',
             round_tutoring_language: 'Swedish',
             round_tutoring_time: 'DAG',
-            round_type: 'Programutbildning',
           },
         ],
         20222: [
@@ -118,7 +116,6 @@ describe('Component <CoursePage>', () => {
             round_tutoring_form: 'NML',
             round_tutoring_language: 'Swedish',
             round_tutoring_time: 'DAG',
-            round_type: 'Programutbildning',
           },
         ],
         20231: [
@@ -147,7 +144,6 @@ describe('Component <CoursePage>', () => {
             round_tutoring_form: 'NML',
             round_tutoring_language: 'Swedish',
             round_tutoring_time: 'DAG',
-            round_type: 'Programutbildning',
           },
         ],
       },

--- a/public/js/app/pages/__tests__/CoursePage.test.js
+++ b/public/js/app/pages/__tests__/CoursePage.test.js
@@ -42,12 +42,11 @@ describe('Component <CoursePage>', () => {
             round_application_code: '60747',
             round_application_link: '<i>No information inserted</i>',
             round_campus: 'KTH Campus',
-            round_category: 'PU',
             round_comment: '',
             round_course_place: 'KTH Campus',
             round_course_term: ['2022', '1'],
             round_end_date: '07/06/2022',
-            round_funding_type: 'LL',
+            round_funding_type: 'ORD',
             round_part_of_programme:
               '<p>\n        <a href="/student/kurser/program/CINEK/20202/arskurs2#inrPPUI">\n          Degree Programme in Industrial Engineering and Management, åk 2, PPUI, Mandatory\n      </a>\n    </p><p>\n        <a href="/student/kurser/program/CMAST/20202/arskurs2">\n          Degree Programme in Mechanical Engineering, åk 2, Mandatory\n      </a>\n    </p><p>\n        <a href="/student/kurser/program/CMAST/20202/arskurs2#inrINTF">\n          Degree Programme in Mechanical Engineering, åk 2, INTF, Mandatory\n      </a>\n    </p><p>\n        <a href="/student/kurser/program/CMAST/20202/arskurs2#inrINTS">\n          Degree Programme in Mechanical Engineering, åk 2, INTS, Mandatory\n      </a>\n    </p><p>\n        <a href="/student/kurser/program/CMAST/20202/arskurs2#inrINTT">\n          Degree Programme in Mechanical Engineering, åk 2, INTT, Mandatory\n      </a>\n    </p>',
             round_periods: 'P3 (4.5 hp), P4 (4.5 hp)',
@@ -70,7 +69,6 @@ describe('Component <CoursePage>', () => {
             round_application_code: '60747',
             round_application_link: '<i>No information inserted</i>',
             round_campus: 'KTH Campus',
-            round_category: 'PU',
             round_comment: '',
             round_course_place: 'KTH Campus',
             round_course_term: ['2022', '1'],
@@ -100,7 +98,6 @@ describe('Component <CoursePage>', () => {
             round_application_code: '60747',
             round_application_link: '<i>No information inserted</i>',
             round_campus: 'KTH Campus',
-            round_category: 'PU',
             round_comment: '',
             round_course_place: 'KTH Campus',
             round_course_term: ['2022', '2'],
@@ -130,7 +127,6 @@ describe('Component <CoursePage>', () => {
             round_application_code: '60747',
             round_application_link: '<i>No information inserted</i>',
             round_campus: 'KTH Campus',
-            round_category: 'PU',
             round_comment: '',
             round_course_place: 'KTH Campus',
             round_course_term: ['2023', '1'],
@@ -220,7 +216,7 @@ describe('Component <CoursePage>', () => {
 
     await user.selectOptions(roundDropdown, '1')
     expect(screen.getByRole('heading', { name: /^Information for/ })).toHaveTextContent(
-      /^Information for Spring 2022 Round B programme students/
+      /^Information for Spring 2022 Round B single courses students/
     )
   })
 })

--- a/server/apiCalls/getFilteredData.js
+++ b/server/apiCalls/getFilteredData.js
@@ -154,9 +154,6 @@ function _getRound(koppsRoundObject = {}, ladokRound, socialSchedules, periods, 
         ? _getRoundProgramme(koppsUsage, language)
         : INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],
     round_state: parseOrSetEmpty(koppsRound.state, language),
-    round_category: hasApplicationCodes
-      ? parseOrSetEmpty(koppsLatestApplicationCode.courseRoundType.category, language)
-      : INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],
   }
   if (courseRoundModel.round_short_name === INFORM_IF_IMPORTANT_INFO_IS_MISSING[language]) {
     courseRoundModel.round_short_name = `${language === 0 ? 'Start' : 'Start'}  ${courseRoundModel.round_start_date}`

--- a/server/apiCalls/getFilteredData.js
+++ b/server/apiCalls/getFilteredData.js
@@ -112,9 +112,6 @@ const createPeriodString = (ladokRound, periods, language) => {
 
 function _getRound(koppsRoundObject = {}, ladokRound, socialSchedules, periods, language = 'sv') {
   const { admissionLinkUrl: koppsAdmissionLinkUrl, round: koppsRound = {}, usage: koppsUsage } = koppsRoundObject
-  const { applicationCodes = [] } = koppsRound
-  const hasApplicationCodes = applicationCodes.length > 0
-  const [koppsLatestApplicationCode] = applicationCodes
   const round = socialSchedules.rounds.find(schedule => schedule.applicationCode === ladokRound.tillfalleskod)
 
   const schemaUrl = round && round.has_events ? round.calendar_url : null
@@ -145,9 +142,6 @@ function _getRound(koppsRoundObject = {}, ladokRound, socialSchedules, periods, 
       language,
       true
     ),
-    round_type: hasApplicationCodes
-      ? parseOrSetEmpty(koppsLatestApplicationCode.courseRoundType.name, language)
-      : INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],
     round_application_link: parseOrSetEmpty(koppsAdmissionLinkUrl, language),
     round_part_of_programme:
       koppsUsage && koppsUsage.length > 0


### PR DESCRIPTION
[KUI-1467](https://kth-se.atlassian.net/browse/KUI-1467?atlOrigin=eyJpIjoiNTM2M2QyYWVmODZmNDNjN2FjNjA5NDFjYmQyMzU2NDYiLCJwIjoiaiJ9)

The main change is in `useRoundUtils.js` where the old suffix creation (containing special and default cases) is replaced by the new specification. 

Had a bit of a hard time navigating overthinking and "getting-it-done" ;-) 
As far as I understand it, we're semantically actually mixing at least 3 things here. (1) Funding type, (2) round type and the (3) "text we want to show to the users". Possibly (2) and (3) actually are the same, but I'm not sure `round type` does not also refer to something else semantically.

- In the end, I opted with moving `VU` (also confirmed by Susanne to still hold meaning) from the removed `round_category` to `round_type_suffix` and implementing the matching in the code. 
- `round_type` in getFilteredData (exposed in context) is not used anymore, so I removed it and related variables.