### PR TITLE
feat(KUI-1472): get all course level code labels from studadm om kurse…

### DIFF
--- a/i18n/messages.en.js
+++ b/i18n/messages.en.js
@@ -149,12 +149,6 @@ module.exports = {
       1: 'Spring ',
       2: 'Autumn ',
     },
-    course_level_code_label: {
-      // PREPARATORY: 'Pre-university level',
-      1: 'First cycle',
-      2: 'Second cycle',
-      3: 'Third cycle',
-    },
     course_department: 'Offered by',
     course_prerequisites: 'Recommended prerequisites',
     course_prerequisites_description:
@@ -164,7 +158,6 @@ module.exports = {
     course_supplemental_information_url_text: 'Supplementary information link text',
     course_supplemental_information: 'Supplementary information ',
     course_examiners: 'Examiner',
-    course_recruitment_text: 'Abstract',
     course_room_canvas: 'Course room in Canvas',
     course_room_canvas_info:
       'Registered students find further information about the implementation of the course in the course room in Canvas. A link to the course room can be found under the tab Studies in the Personal menu at the start of the course.',

--- a/i18n/messages.se.js
+++ b/i18n/messages.se.js
@@ -151,20 +151,6 @@ module.exports = {
       1: 'VT ',
       2: 'HT ',
     },
-    // course_level_code_label: {
-    //   PREPARATORY: 'Förberedande nivå',
-    //   BASIC: 'Grundnivå',
-    //   ADVANCED: 'Avancerad nivå',
-    //   RESEARCH: 'Forskarnivå',
-    // },
-    // TODO(Ladok-POC): Use nameSv/nameEn from utbildningstyp.niva.inom.studieordning instead?
-    // TODO(Ladok-POC): level code doesn't work for PREPARATORY, look into ladok data more
-    course_level_code_label: {
-      // PREPARATORY: 'Förberedande nivå',
-      1: 'Grundnivå',
-      2: 'Avancerad nivå',
-      3: 'Forskarnivå',
-    },
     course_department: 'Ges av',
     course_prerequisites: 'Rekommenderade förkunskaper',
     course_prerequisites_description:
@@ -174,7 +160,6 @@ module.exports = {
     course_supplemental_information_url_text: 'Övrig information - länk text',
     course_supplemental_information: 'Övrig information',
     course_examiners: 'Examinator',
-    course_recruitment_text: 'Kort beskrivning svenska',
     course_room_canvas: 'Kursrum i Canvas',
     course_room_canvas_info:
       'Registrerade studenter hittar information för genomförande av kursen i kursrummet i Canvas. En länk till kursrummet finns under fliken Studier i Personliga menyn vid kursstart.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@kth/kth-node-web-common": "^9.3.1",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "^1.3.0",
+        "@kth/om-kursen-ladok-client": "^1.3.2",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.4.2",
@@ -92,7 +92,7 @@
     },
     "../studadm-om-kursen-packages/packages/om-kursen-ladok-client": {
       "name": "@kth/om-kursen-ladok-client",
-      "version": "1.3.0",
+      "version": "1.3.2",
       "dependencies": {
         "@kth/ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
         "@kth/ladok-mellanlager-client": "file:../ladok-mellanlager-client",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@kth/kth-node-web-common": "^9.3.1",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.3.1",
-    "@kth/om-kursen-ladok-client": "^1.3.0",
+    "@kth/om-kursen-ladok-client": "^1.3.2",
     "@kth/server": "^4.1.0",
     "@kth/session": "^3.0.9",
     "@kth/style": "^1.4.2",

--- a/public/js/app/components/CourseSectionList.jsx
+++ b/public/js/app/components/CourseSectionList.jsx
@@ -123,7 +123,7 @@ function CourseSectionList({ courseInfo = {}, partToShow, syllabus = {}, syllabu
       },
       {
         header: translation.courseInformation.course_level_code,
-        text: translation.courseInformation.course_level_code_label[courseInfo.course_level_code],
+        text: courseInfo.course_level_code_label,
         syllabusMarker: true,
       },
     ]

--- a/public/js/app/components/MainCourseInformation.jsx
+++ b/public/js/app/components/MainCourseInformation.jsx
@@ -53,7 +53,7 @@ const MainCourseInformation = ({ courseCode, courseData, semesterRoundState }) =
       />
 
       {/* ---IF RESEARCH LEVEL: SHOW "Postgraduate course" LINK--  */}
-      {courseInfo.course_level_code === 'RESEARCH' && (
+      {courseInfo.course_level_code === '3' && (
         <span>
           <h3>{translation.courseLabels.header_postgraduate_course}</h3>
           {translation.courseLabels.label_postgraduate_course}

--- a/public/js/app/components/MainCourseInformation.jsx
+++ b/public/js/app/components/MainCourseInformation.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { EducationalLevelCode } from '@kth/om-kursen-ladok-client'
 import Alert from '../components-shared/Alert'
 
 import { FORSKARUTB_URL } from '../util/constants'
@@ -53,12 +54,12 @@ const MainCourseInformation = ({ courseCode, courseData, semesterRoundState }) =
       />
 
       {/* ---IF RESEARCH LEVEL: SHOW "Postgraduate course" LINK--  */}
-      {courseInfo.course_level_code === '3' && (
-        <span>
+      {courseInfo.course_level_code === EducationalLevelCode.Research && (
+        <div className="course-section-list">
           <h3>{translation.courseLabels.header_postgraduate_course}</h3>
           {translation.courseLabels.label_postgraduate_course}
           <a href={`${FORSKARUTB_URL}${courseInfo.course_department_code}`}>{courseInfo.course_department}</a>
-        </span>
+        </div>
       )}
     </>
   )

--- a/server/apiCalls/getFilteredData.js
+++ b/server/apiCalls/getFilteredData.js
@@ -21,7 +21,7 @@ const { getSocial } = require('./socialApi')
 function _parseCourseDefaultInformation(koppsCourseDetails, ladokCourse, ladokSyllabus, language) {
   const { course: koppsCourse } = koppsCourseDetails
 
-  const mainSubjects = ladokSyllabus.course.huvudomraden.map(huvudomrade => huvudomrade[language])
+  const mainSubjects = ladokSyllabus.course.huvudomraden?.map(huvudomrade => huvudomrade[language])
 
   return {
     course_code: parseOrSetEmpty(ladokCourse.kod),
@@ -30,6 +30,7 @@ function _parseCourseDefaultInformation(koppsCourseDetails, ladokCourse, ladokSy
     course_department_link: buildCourseDepartmentLink(ladokCourse.organisation, language),
     course_education_type_id: ladokCourse.utbildningstyp?.id,
     course_level_code: parseOrSetEmpty(ladokSyllabus.course.nivainomstudieordning.level.code),
+    course_level_code_label: parseOrSetEmpty(ladokSyllabus.course.nivainomstudieordning.level[language], language),
     course_main_subject:
       mainSubjects && mainSubjects.length > 0
         ? mainSubjects.join(', ')

--- a/server/controllers/__tests__/courseCtrl.test.js
+++ b/server/controllers/__tests__/courseCtrl.test.js
@@ -142,6 +142,7 @@ describe('Discontinued course to test', () => {
         "course_grade_scale": "A, B, C, D, E, FX, F",
         "course_last_exam": [],
         "course_level_code": "1",
+        "course_level_code_label": "Grundnivå",
         "course_literature": "<i>Ingen information tillagd</i>",
         "course_main_subject": "Samhällsbyggnad, Teknik",
         "course_prerequisites": "<i>Ingen information tillagd</i>",


### PR DESCRIPTION
…n packages

Flyttat hårdkodad logik för förberedande utbildningsnivå till `studadm-om-kursen-packages/ladok-attributvarde-utils`: https://github.com/KTH/studadm-om-kursen-packages/pull/61/files 

Exempel på olika utbildningsnivå för att testa denna PR:
* Förberedande: HF0025 http://localhost:3000/student/kurser/kurs/HF0025
* Grundnivå: SF1624 http://localhost:3000/student/kurser/kurs/SF1624
* Avancerad nivå: LH216V http://localhost:3000/student/kurser/kurs/LH216V
* Forskarnivå: FME3532 http://localhost:3000/student/kurser/kurs/FME3532