### PR TITLE
fix(KUI-1840): remove formatting of examination titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@kth/kth-node-web-common": "^9.3.1",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "^1.3.12",
+        "@kth/om-kursen-ladok-client": "^2.0.0",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.4.2",
@@ -89,16 +89,6 @@
       },
       "engines": {
         "node": "20"
-      }
-    },
-    "../studadm-om-kursen-packages/packages/om-kursen-ladok-client": {
-      "name": "@kth/om-kursen-ladok-client",
-      "version": "1.3.13",
-      "dependencies": {
-        "@kth/ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
-        "@kth/ladok-mellanlager-client": "file:../ladok-mellanlager-client",
-        "date-fns": "^4.1.0",
-        "showdown": "^2.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3022,6 +3012,19 @@
         "@kth/log": "^4.0.5"
       }
     },
+    "node_modules/@kth/ladok-attributvarde-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-1.0.0.tgz",
+      "integrity": "sha512-Iz/NCjj8iZDutjh5kJdnc8KEmnfYErmVgNwMH8IwnJJ0l3GJff73+IaqrHydlfebyHPFqQCcPCpxUCX6C5rZ2w=="
+    },
+    "node_modules/@kth/ladok-mellanlager-client": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-1.0.0.tgz",
+      "integrity": "sha512-kPILXlG5v7YcVFxdD5mkHsY36WuLYOIv+4N+bbZDbrzG5gbrqXnFQtija3xGjaI5jaU0Ue3JrhtQBxFRNXeBzA==",
+      "dependencies": {
+        "openapi-fetch": "^0.13.0"
+      }
+    },
     "node_modules/@kth/log": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@kth/log/-/log-4.0.7.tgz",
@@ -3042,8 +3045,25 @@
       }
     },
     "node_modules/@kth/om-kursen-ladok-client": {
-      "resolved": "../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
-      "link": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-2.0.0.tgz",
+      "integrity": "sha512-zwzReKEC5avRQrqd1/s8DZnN0llleLps4JtX+XRKqeQZXSYpl/kh9zzE14/jTmFUBlHTaEB++GTN5DGsL+eC5w==",
+      "dependencies": {
+        "@kth/ladok-attributvarde-utils": "1.0.0",
+        "@kth/ladok-mellanlager-client": "1.0.0",
+        "date-fns": "^4.1.0",
+        "showdown": "^2.1.0"
+      }
+    },
+    "node_modules/@kth/om-kursen-ladok-client/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/@kth/server": {
       "version": "4.1.0",
@@ -13457,6 +13477,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.8.tgz",
+      "integrity": "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -15552,6 +15587,31 @@
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
+      }
+    },
+    "node_modules/showdown/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@kth/kth-node-web-common": "^9.3.1",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "^1.3.12",
+        "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.4.2",
@@ -89,6 +89,16 @@
       },
       "engines": {
         "node": "20"
+      }
+    },
+    "../studadm-om-kursen-packages/packages/om-kursen-ladok-client": {
+      "name": "@kth/om-kursen-ladok-client",
+      "version": "1.3.13",
+      "dependencies": {
+        "@kth/ladok-attributvarde-utils": "file:../ladok-attributvarde-utils",
+        "@kth/ladok-mellanlager-client": "file:../ladok-mellanlager-client",
+        "date-fns": "^4.1.0",
+        "showdown": "^2.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3012,19 +3022,6 @@
         "@kth/log": "^4.0.5"
       }
     },
-    "node_modules/@kth/ladok-attributvarde-utils": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-attributvarde-utils/-/ladok-attributvarde-utils-0.1.8.tgz",
-      "integrity": "sha512-ey86Vb5f10tSLPwzLFjwBQvrJnCTOtEN2qIXsxm9BtGhAVxdmo4bdVAxv0Ke2afQWcoCIMP+8U0hmCEBFeLYMw=="
-    },
-    "node_modules/@kth/ladok-mellanlager-client": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-0.4.7.tgz",
-      "integrity": "sha512-gzqcBVC60pugOZt5oD1gq5Jli4096Mjwo4ahe0WUDrDnGThhiDu6EPsqYKBA5oro4U1de3dDTz8TyLC09+sAcQ==",
-      "dependencies": {
-        "openapi-fetch": "^0.13.0"
-      }
-    },
     "node_modules/@kth/log": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@kth/log/-/log-4.0.7.tgz",
@@ -3045,25 +3042,8 @@
       }
     },
     "node_modules/@kth/om-kursen-ladok-client": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-1.3.12.tgz",
-      "integrity": "sha512-wIPUq99P4KWPybKMMT1xOvTndOszXH5VDXWluBiWySeqw4QR9BAkKTWRPHDhZgyWWzd+4ETpB+VDnp22zES4lw==",
-      "dependencies": {
-        "@kth/ladok-attributvarde-utils": "0.1.8",
-        "@kth/ladok-mellanlager-client": "0.4.7",
-        "date-fns": "^4.1.0",
-        "showdown": "^2.1.0"
-      }
-    },
-    "node_modules/@kth/om-kursen-ladok-client/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
+      "resolved": "../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+      "link": true
     },
     "node_modules/@kth/server": {
       "version": "4.1.0",
@@ -13477,21 +13457,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openapi-fetch": {
-      "version": "0.13.8",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.8.tgz",
-      "integrity": "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "openapi-typescript-helpers": "^0.0.15"
-      }
-    },
-    "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
-      "license": "MIT"
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -15587,31 +15552,6 @@
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/showdown": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
-      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^9.0.0"
-      },
-      "bin": {
-        "showdown": "bin/showdown.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://www.paypal.me/tiviesantos"
-      }
-    },
-    "node_modules/showdown/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@kth/kth-node-web-common": "^9.3.1",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+        "@kth/om-kursen-ladok-client": "^1.3.12",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@kth/kth-node-web-common": "^9.3.1",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.3.1",
-    "@kth/om-kursen-ladok-client": "^1.3.12",
+    "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
     "@kth/server": "^4.1.0",
     "@kth/session": "^3.0.9",
     "@kth/style": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@kth/kth-node-web-common": "^9.3.1",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.3.1",
-    "@kth/om-kursen-ladok-client": "^1.3.12",
+    "@kth/om-kursen-ladok-client": "^2.0.0",
     "@kth/server": "^4.1.0",
     "@kth/session": "^3.0.9",
     "@kth/style": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@kth/kth-node-web-common": "^9.3.1",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.3.1",
-    "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
+    "@kth/om-kursen-ladok-client": "^1.3.12",
     "@kth/server": "^4.1.0",
     "@kth/session": "^3.0.9",
     "@kth/style": "^1.4.2",

--- a/public/css/kursinfo-web.scss
+++ b/public/css/kursinfo-web.scss
@@ -286,10 +286,6 @@
   }
 }
 
-.ul-no-padding {
-  padding-left: 20px;
-}
-
 /****ICONS*****/
 .icon-schedule {
   position: relative;

--- a/public/js/app/hooks/__tests__/useSemesterRoundState.test.js
+++ b/public/js/app/hooks/__tests__/useSemesterRoundState.test.js
@@ -177,8 +177,7 @@ const syllabusList = [
       semesterNumber: 2,
     },
     course_valid_to: [],
-    course_examination:
-      "<ul class='ul-no-padding' ><li>TEN1 - \n                          Examination,\n                          7.5  credits,  \n                          grading scale: A, B, C, D, E, FX, F              \n                          </li></ul>",
+    course_examination: '<ul><li>TEN1 - Examination, 7.5 credits, grading scale: A, B, C, D, E, FX, F</li></ul>',
     course_examination_comments:
       'Based on recommendation from KTH’s coordinator for disabilities, the examiner will decide how to adapt an examination for students with documented disability. <br><br>The examiner may apply another examination format when re-examining individual students.<p>The examiner decides, in consultation with KTHs Coordinator of students with disabilities (Funka), about any customized examination for students with documented, lasting disability.&#160;</p>',
     course_ethical:
@@ -204,8 +203,7 @@ const syllabusList = [
       year: 2019,
       semesterNumber: 1,
     },
-    course_examination:
-      "<ul class='ul-no-padding' ><li>TEN1 - \n                          Examination,\n                          7.5  credits,  \n                          grading scale: A, B, C, D, E, FX, F              \n                          </li></ul>",
+    course_examination: '<ul><li>TEN1 - Examination, 7.5  credits, grading scale: A, B, C, D, E, FX, F</li></ul>',
     course_examination_comments:
       'Based on recommendation from KTH’s coordinator for disabilities, the examiner will decide how to adapt an examination for students with documented disability. <br><br>The examiner may apply another examination format when re-examining individual students.',
     course_ethical:

--- a/server/controllers/__tests__/courseCtrl.test.js
+++ b/server/controllers/__tests__/courseCtrl.test.js
@@ -197,7 +197,7 @@ describe('Discontinued course to test', () => {
 <li>Vid examination ska varje student ärligt redovisa hjälp som erhållits och källor som använts.</li>
 <li>Vid muntlig examination ska varje student kunna redogöra för hela uppgiften och hela lösningen.</li>
 </ul>",
-          "course_examination": "<ul class='ul-no-padding' ><li>ÖVN1 - Fältövningar, 3,0 hp, Tvågradig betygsskala: P, F</li><li>TEN1 - Tentamen, 4,5 hp, Sjugradig betygsskala: A, B, C, D, E, FX, F</li></ul>",
+          "course_examination": "<ul><li>ÖVN1 - Fältövningar, 3,0 hp, Tvågradig betygsskala: P, F</li><li>TEN1 - Tentamen, 4,5 hp, Sjugradig betygsskala: A, B, C, D, E, FX, F</li></ul>",
           "course_examination_comments": "<p>Examinator beslutar, baserat på rekommendation från KTH:s handläggare av stöd till studenter med funktionsnedsättning, om eventuell anpassad examination för studenter med dokumenterad, varaktig funktionsnedsättning.</p>
 <p>Examinator får medge annan examinationsform vid omexamination av enstaka studenter.</p>
 <p>När kurs inte längre ges har student möjlighet att examineras under ytterligare två läsår.</p>",

--- a/server/controllers/__tests__/createSyllabusList.test.js
+++ b/server/controllers/__tests__/createSyllabusList.test.js
@@ -17,7 +17,7 @@ const expectedSyllabusList = [
     },
     course_valid_to: undefined,
     course_examination:
-      "<ul class='ul-no-padding' ><li>ÖVN1 - Fältövningar, 3,0 hp, Tvågradig betygsskala: P, F</li><li>TEN1 - Tentamen, 4,5 hp, Sjugradig betygsskala: A, B, C, D, E, FX, F</li></ul>",
+      '<ul><li>ÖVN1 - Fältövningar, 3,0 hp, Tvågradig betygsskala: P, F</li><li>TEN1 - Tentamen, 4,5 hp, Sjugradig betygsskala: A, B, C, D, E, FX, F</li></ul>',
     course_examination_comments:
       '<p>Examinator beslutar, baserat på rekommendation från KTH:s handläggare av stöd till studenter med funktionsnedsättning, om eventuell anpassad examination för studenter med dokumenterad, varaktig funktionsnedsättning.</p>\n<p>Examinator får medge annan examinationsform vid omexamination av enstaka studenter.</p>\n<p>När kurs inte längre ges har student möjlighet att examineras under ytterligare två läsår.</p>',
     course_ethical:
@@ -37,7 +37,7 @@ const expectedEmpty = [
     course_decision_to_discontinue: '<i>Ingen information tillagd</i>',
     course_eligibility: '<i>Ingen information tillagd</i>',
     course_ethical: '',
-    course_examination: "<ul class='ul-no-padding' ><li></li><li></li></ul>",
+    course_examination: '',
     course_examination_comments: '',
     course_goals: '<i>Ingen information tillagd</i>',
     course_literature: '<i>Ingen information tillagd</i>',

--- a/server/controllers/createSyllabusList.js
+++ b/server/controllers/createSyllabusList.js
@@ -2,17 +2,6 @@ const { INFORM_IF_IMPORTANT_INFO_IS_MISSING } = require('../util/constants')
 const { parseSemesterIntoYearSemesterNumber } = require('../util/semesterUtils')
 const { parseOrSetEmpty } = require('./courseCtrlHelpers')
 
-const _parseExamObject = examinationModules => {
-  const { completeExaminationStrings } = examinationModules
-  let examString = "<ul class='ul-no-padding' >"
-  completeExaminationStrings.forEach(examinationModule => {
-    examString += `<li>${examinationModule}</li>`
-  })
-
-  examString += '</ul>'
-  return examString
-}
-
 const _createEmptySyllabusData = language => ({
   course_goals: INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],
   course_content: INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],
@@ -41,10 +30,7 @@ const _mapSyllabus = (syllabus, language) => {
     course_literature: parseOrSetEmpty(syllabus.kursplan.kurslitteratur, language),
     course_valid_from: parseSemesterIntoYearSemesterNumber(parseOrSetEmpty(syllabus.kursplan.giltigfrom)),
     course_valid_to: undefined,
-    course_examination:
-      syllabus.kursplan.examinationModules && syllabus.kursplan.examinationModules.completeExaminationStrings.length > 0
-        ? _parseExamObject(syllabus.kursplan.examinationModules)
-        : INFORM_IF_IMPORTANT_INFO_IS_MISSING[language],
+    course_examination: syllabus.kursplan.examinationModules.completeExaminationStrings,
     course_examination_comments: parseOrSetEmpty(syllabus.kursplan.kommentartillexamination, language, true),
     course_ethical: parseOrSetEmpty(syllabus.kursplan.etisktforhallandesatt, language, true),
     course_additional_regulations: parseOrSetEmpty(syllabus.kursplan.faststallande, language, true),

--- a/server/controllers/mocks/mockedLadokData.js
+++ b/server/controllers/mocks/mockedLadokData.js
@@ -23,8 +23,9 @@ const mockedLadokCourseVersion = {
 const mockedLadokRounds = []
 
 const mockedExaminationModules = {
-  completeExaminationStrings: ['TEN1 - Examination, 7.5 credits, Seven point grading scale: A, B, C, D, E, FX, F'],
-  titles: ['TEN1 - Examination, 7.5 credits'],
+  completeExaminationStrings:
+    '<ul><li>TEN1 - Examination, 7.5 credits, Seven point grading scale: A, B, C, D, E, FX, F</li></ul>',
+  titles: '<h4>TEN1 - Examination, 7.5 credits</h4>',
 }
 
 const mockedCourseSyllabus = {
@@ -84,11 +85,9 @@ const mockedCourseSyllabus = {
       '<ul>\n<li>Vid grupparbete har alla i gruppen ansvar för gruppens arbete.</li>\n<li>Vid examination ska varje student ärligt redovisa hjälp som erhållits och källor som använts.</li>\n<li>Vid muntlig examination ska varje student kunna redogöra för hela uppgiften och hela lösningen.</li>\n</ul>',
     faststallande: '<p>Kursplanen gäller från HT19.</p>',
     examinationModules: {
-      completeExaminationStrings: [
-        'ÖVN1 - Fältövningar, 3,0 hp, Tvågradig betygsskala: P, F',
-        'TEN1 - Tentamen, 4,5 hp, Sjugradig betygsskala: A, B, C, D, E, FX, F',
-      ],
-      titles: ['ÖVN1 - Fältövningar, 3,0 hp', 'TEN1 - Tentamen, 4,5 hp'],
+      completeExaminationStrings:
+        '<ul><li>ÖVN1 - Fältövningar, 3,0 hp, Tvågradig betygsskala: P, F</li><li>TEN1 - Tentamen, 4,5 hp, Sjugradig betygsskala: A, B, C, D, E, FX, F</li></ul>',
+      titles: '<h4>ÖVN1 - Fältövningar, 3,0 hp</h4><h4>TEN1 - Tentamen, 4,5 hp</h4>',
     },
     kommentartillexamination:
       '<p>Examinator beslutar, baserat på rekommendation från KTH:s handläggare av stöd till studenter med funktionsnedsättning, om eventuell anpassad examination för studenter med dokumenterad, varaktig funktionsnedsättning.</p>\n<p>Examinator får medge annan examinationsform vid omexamination av enstaka studenter.</p>\n<p>När kurs inte längre ges har student möjlighet att examineras under ytterligare två läsår.</p>',
@@ -153,8 +152,8 @@ const mockedUndefinedCourseSyllabus = {
     etisktforhallandesatt: '',
     faststallande: '',
     examinationModules: {
-      completeExaminationStrings: ['', ''],
-      titles: ['', ''],
+      completeExaminationStrings: '',
+      titles: '',
     },
     kommentartillexamination: '',
     ovrigakravforslutbetyg: '',


### PR DESCRIPTION
Uses `studadm-om-kursen-packages` from this PR: https://github.com/KTH/studadm-om-kursen-packages/pull/89

Please check that the examinations modules are formatted correctly:

http://localhost:3000/student/kurser/kurs/MJ1112


_____


 ```
 "@kth/om-kursen-ladok-client": "file:../studadm-om-kursen-packages/packages/om-kursen-ladok-client",
 ```
 
 will be removed when updating the PR with the published `studadm-om-kursen-packages`.
