### PR TITLE
fix(KUI-1861): prevents error if kopps returns 404

### DIFF
--- a/server/apiCalls/__tests__/koppsCourseData.test.js
+++ b/server/apiCalls/__tests__/koppsCourseData.test.js
@@ -60,34 +60,30 @@ describe('getKoppsCourseData', () => {
     }
   }
 
-  it('should throw error if getAsync called with language=en and resolves with 404', async () => {
+  const expectedReturnedObjectOn404 = { statusCode: 404, body: {} }
+
+  it('should ignore error if getAsync called with language=en and resolves with 404', async () => {
     const { mockGetAsync } = require('../mocks/mockedKthApiCall')
 
-    const expectedErrorEnglish = new Error(
-      `Sorry, we can't find your requested page: basePath/course/someCourseCode/detailedinformation?l=en`
-    )
     mockGetAsync.mockResolvedValueOnce({
       statusCode: 404,
     })
 
-    const error = await getError(getKoppsCourseData('someCourseCode', 'en'))
+    const error = await getKoppsCourseData('someCourseCode', 'en')
 
-    expect(error).toEqual(expectedErrorEnglish)
+    expect(error).toEqual(expectedReturnedObjectOn404)
   })
 
-  it('should throw error if getAsync called with language=sv and resolves with 404', async () => {
+  it('should ignore error if getAsync called with language=sv and resolves with 404', async () => {
     const { mockGetAsync } = require('../mocks/mockedKthApiCall')
 
-    const expectedErrorSwedish = new Error(
-      `Tyvärr kunde vi inte hitta sidan du efterfrågade: basePath/course/someCourseCode/detailedinformation?l=sv`
-    )
     mockGetAsync.mockResolvedValueOnce({
       statusCode: 404,
     })
 
-    const error = await getError(getKoppsCourseData('someCourseCode', 'sv'))
+    const error = await getKoppsCourseData('someCourseCode', 'sv')
 
-    expect(error).toEqual(expectedErrorSwedish)
+    expect(error).toEqual(expectedReturnedObjectOn404)
   })
 
   it('should throw error if getAsync rejects with error', async () => {

--- a/server/apiCalls/errorUtils.js
+++ b/server/apiCalls/errorUtils.js
@@ -18,6 +18,15 @@ const callApiAndPossiblyHandle404 = async ({ client, uri, lang = undefined }) =>
   return response
 }
 
+const callApiAndIgnore404 = async ({ client, uri }) => {
+  const response = await client.getAsync({ uri, useCache: true })
+  if (response.statusCode === HTTP_CODE_404) {
+    return { body: {}, statusCode: HTTP_CODE_404 }
+  }
+  return response
+}
+
 module.exports = {
   callApiAndPossiblyHandle404,
+  callApiAndIgnore404,
 }

--- a/server/apiCalls/koppsCourseData.js
+++ b/server/apiCalls/koppsCourseData.js
@@ -4,7 +4,7 @@ const log = require('@kth/log')
 const redis = require('kth-node-redis')
 const connections = require('@kth/api-call').Connections
 const { server: config } = require('../configuration')
-const { callApiAndPossiblyHandle404 } = require('./errorUtils')
+const { callApiAndIgnore404 } = require('./errorUtils')
 
 const koppsOpts = {
   log,
@@ -30,7 +30,7 @@ async function getKoppsCourseData(courseCode, lang = 'sv') {
   const { client } = api.koppsApi
   const uri = `${config.koppsApi.basePath}course/${encodeURIComponent(courseCode)}/detailedinformation?l=${lang}`
   try {
-    return callApiAndPossiblyHandle404({ client, uri, lang })
+    return callApiAndIgnore404({ client, uri, lang })
   } catch (err) {
     log.debug('Kopps is not available', err)
     return err


### PR DESCRIPTION
https://kth-se.atlassian.net/browse/KUI-1861

The proposed change will ignore a 404-error from kopps and return an empty object, which in turn has the result that the page will render.