### PR TITLE
Issues/KUI 1886 1875 correct syllabus

### DIFF
--- a/server/apiCalls/getFilteredData.js
+++ b/server/apiCalls/getFilteredData.js
@@ -234,9 +234,6 @@ function _parseRounds({
 }
 
 const getFilteredData = async ({ courseCode, language, memoList }) => {
-  const now = new Date()
-  const period = getPeriodCodeForDate(now)
-
   const [
     { body: koppsCourseDetails },
     { course: ladokCourse, rounds: ladokRounds },

--- a/server/apiCalls/getFilteredData.js
+++ b/server/apiCalls/getFilteredData.js
@@ -240,19 +240,20 @@ const getFilteredData = async ({ courseCode, language, memoList }) => {
   const [
     { body: koppsCourseDetails },
     { course: ladokCourse, rounds: ladokRounds },
-    ladokSyllabus,
+    ladokSyllabuses,
     periods,
     socialSchedules,
   ] = await Promise.all([
     koppsCourseData.getKoppsCourseData(courseCode, language),
     ladokApi.getCourseAndRounds(courseCode, language),
-    ladokApi.getLadokSyllabus(courseCode, period, language),
+    ladokApi.getLadokSyllabuses(courseCode, language),
     ladokApi.getPeriods(),
     getSocial(courseCode, language),
   ])
 
   //* **** Course information that is static on the course side *****//
-  const courseDefaultInformation = _parseCourseDefaultInformation(ladokCourse, ladokSyllabus, language)
+  // We use the latest valid ladok syllabus here since the information that we are using inside _parseCourseDefaultInformation are general data inside syllabuses
+  const courseDefaultInformation = _parseCourseDefaultInformation(ladokCourse, ladokSyllabuses[0], language)
 
   const { sellingText, courseDisposition, recommendedPrerequisites, supplementaryInfo, imageInfo } =
     await courseApi.getCourseInfo(courseCode)
@@ -270,7 +271,7 @@ const getFilteredData = async ({ courseCode, language, memoList }) => {
   const courseTitleData = _parseTitleData(ladokCourse, language)
 
   //* **** Get list of syllabuses and valid syllabus semesters *****//
-  const { syllabusList, emptySyllabusData } = createSyllabusList(ladokSyllabus, language)
+  const { syllabusList, emptySyllabusData } = createSyllabusList(ladokSyllabuses, language)
 
   //* **** Get a list of rounds and a list of redis keys for using to get teachers and responsibles from UG Rest API *****//
   const { roundsBySemester, activeSemesters, employees } = _parseRounds({

--- a/server/apiCalls/ladokApi.js
+++ b/server/apiCalls/ladokApi.js
@@ -29,17 +29,6 @@ async function getExaminationModules(courseUid, language) {
   }
 }
 
-async function getLadokSyllabus(courseCode, semester, lang) {
-  try {
-    const syllabus = await client.getCourseSyllabus(courseCode, semester, lang)
-
-    return syllabus
-  } catch (error) {
-    log.error(error.message)
-    return undefined
-  }
-}
-
 async function getLadokSyllabuses(courseCode, lang) {
   try {
     const syllabuses = await client.getAllValidCourseSyllabuses(courseCode, lang)
@@ -65,7 +54,6 @@ async function getPeriods() {
 module.exports = {
   getCourseAndRounds,
   getExaminationModules,
-  getLadokSyllabus,
   getLadokSyllabuses,
   getPeriods,
 }

--- a/server/apiCalls/ladokApi.js
+++ b/server/apiCalls/ladokApi.js
@@ -31,9 +31,20 @@ async function getExaminationModules(courseUid, language) {
 
 async function getLadokSyllabus(courseCode, semester, lang) {
   try {
-    const course = await client.getCourseSyllabus(courseCode, semester, lang)
+    const syllabus = await client.getCourseSyllabus(courseCode, semester, lang)
 
-    return course
+    return syllabus
+  } catch (error) {
+    log.error(error.message)
+    return undefined
+  }
+}
+
+async function getLadokSyllabuses(courseCode, lang) {
+  try {
+    const syllabuses = await client.getAllValidCourseSyllabuses(courseCode, lang)
+
+    return syllabuses
   } catch (error) {
     log.error(error.message)
     return undefined
@@ -55,5 +66,6 @@ module.exports = {
   getCourseAndRounds,
   getExaminationModules,
   getLadokSyllabus,
+  getLadokSyllabuses,
   getPeriods,
 }

--- a/server/controllers/__tests__/createSyllabusList.test.js
+++ b/server/controllers/__tests__/createSyllabusList.test.js
@@ -54,12 +54,12 @@ const expectedEmpty = [
 
 describe('createSyllabusList', () => {
   test('creates syllabus list', () => {
-    const { syllabusList } = createSyllabusList(mockedLadokData.mockedCourseSyllabus, 'sv')
+    const { syllabusList } = createSyllabusList([mockedLadokData.mockedCourseSyllabus], 'sv')
 
     expect(syllabusList).toEqual(expectedSyllabusList)
   })
   test('if empty publicSyllabusVersions, returns empty array', () => {
-    const { syllabusList } = createSyllabusList(mockedLadokData.mockedUndefinedCourseSyllabus, 'sv')
+    const { syllabusList } = createSyllabusList([mockedLadokData.mockedUndefinedCourseSyllabus], 'sv')
 
     expect(syllabusList).toEqual(expectedEmpty)
   })

--- a/server/controllers/createSyllabusList.js
+++ b/server/controllers/createSyllabusList.js
@@ -42,7 +42,7 @@ const _mapSyllabus = (syllabus, language) => {
 const createSyllabusList = (syllabuses, lang) => {
   const emptySyllabusData = _createEmptySyllabusData(lang)
 
-  if (!syllabuses || !syllabuses.length) {
+  if (!syllabuses?.length) {
     return {
       syllabusList: [],
       emptySyllabusData,
@@ -53,9 +53,13 @@ const createSyllabusList = (syllabuses, lang) => {
   for (let index = 0; index < syllabuses.length; index++) {
     const syllabus = _mapSyllabus(syllabuses[index], lang)
 
-    const previousSyllabus = syllabusList[index - 1]
-    if (previousSyllabus) {
-      syllabus.course_valid_to = calcPreviousSemester(previousSyllabus.course_valid_from)
+    /* The syllabuses list we get from the om-kursen-ladok-client package is sorted from newest to oldest.
+     * This means we can determine how long each syllabus is valid by looking at the previous item in the list
+     * — which is the newer syllabus — to know until which semester it's valid.
+     */
+    const newerSyllabus = syllabusList[index - 1]
+    if (newerSyllabus) {
+      syllabus.course_valid_to = calcPreviousSemester(newerSyllabus.course_valid_from)
     }
 
     syllabusList.push(syllabus)

--- a/server/controllers/createSyllabusList.js
+++ b/server/controllers/createSyllabusList.js
@@ -55,7 +55,7 @@ const createSyllabusList = (syllabuses, lang) => {
 
     const previousSyllabus = syllabusList[index - 1]
     if (previousSyllabus) {
-      syllabus.course_valid_to = calcPreviousSemester(syllabus.course_valid_from)
+      syllabus.course_valid_to = calcPreviousSemester(previousSyllabus.course_valid_from)
     }
 
     syllabusList.push(syllabus)

--- a/server/controllers/createSyllabusList.js
+++ b/server/controllers/createSyllabusList.js
@@ -1,5 +1,5 @@
 const { INFORM_IF_IMPORTANT_INFO_IS_MISSING } = require('../util/constants')
-const { parseSemesterIntoYearSemesterNumber } = require('../util/semesterUtils')
+const { parseSemesterIntoYearSemesterNumber, calcPreviousSemester } = require('../util/semesterUtils')
 const { parseOrSetEmpty } = require('./courseCtrlHelpers')
 
 const _createEmptySyllabusData = language => ({
@@ -39,10 +39,10 @@ const _mapSyllabus = (syllabus, language) => {
   }
 }
 
-const createSyllabusList = (syllabus, lang) => {
+const createSyllabusList = (syllabuses, lang) => {
   const emptySyllabusData = _createEmptySyllabusData(lang)
 
-  if (!syllabus) {
+  if (!syllabuses || !syllabuses.length) {
     return {
       syllabusList: [],
       emptySyllabusData,
@@ -50,10 +50,16 @@ const createSyllabusList = (syllabus, lang) => {
   }
 
   const syllabusList = []
+  for (let index = 0; index < syllabuses.length; index++) {
+    const syllabus = _mapSyllabus(syllabuses[index], lang)
 
-  const mappedSyllabus = _mapSyllabus(syllabus, lang)
+    const previousSyllabus = syllabusList[index - 1]
+    if (previousSyllabus) {
+      syllabus.course_valid_to = calcPreviousSemester(syllabus.course_valid_from)
+    }
 
-  syllabusList.push(mappedSyllabus)
+    syllabusList.push(syllabus)
+  }
 
   return {
     syllabusList,


### PR DESCRIPTION
Currently, our logic only shows the course syllabus based on the current date. This means that if a course has a future course round (like [this example](https://www.kth.se/student/kurser/kurs/ME1044?l=en)), the correct syllabus for that round is not displayed.

What we’ve decided to change
After discussing with Amanda, we’ve agreed to update the logic as follows:

1. Show the correct syllabus for each course round:
For all course rounds (both ongoing and upcoming), we should display the syllabus that is valid for the start date of that round, not based on today’s date.

2. Update syllabus when switching course rounds:
When the user changes the selected course round, we should automatically show the syllabus that is valid for the new round’s start date.

I have tried to compare the old logic (before using ladok data) with our current logic and some of the changes are the same as our logic before using ladok.


My source for comparison: https://github.com/KTH/kursinfo-web/blob/issues/KUI-1400-upgrade-kth/style/server/controllers/createSyllabusList.js (Also other files from the same branch)