### PR TITLE
docs(KUI-1553): add investigation results regarding CSRF waning as a comment

### DIFF
--- a/public/js/app/components/statistics/StatisticsForm.jsx
+++ b/public/js/app/components/statistics/StatisticsForm.jsx
@@ -54,10 +54,39 @@ function StatisticsForm({ onSubmit, resultError }) {
     setState({ value: params, type: 'UPDATE_STATE' })
   }
 
+  /**
+   * Detectify reports missing CSRF token on this form
+   *
+   * ✅ Why this is not a security issue:
+   *
+   * 1. It only triggers authenticated GET requests that do not modify server state.
+   *    - “GET requests are to be used for idempotent requests, or requests that do not change state. These requests do not need to have anti‑CSRF tokens.”
+   *      source: https://security.stackexchange.com/questions/115794/should-i-use-csrf-protection-for-get-requests
+   *
+   * 2. The request is made using a secret tokens stored in environment variables (never exposed to the browser).
+   *    - “CSRF attacks rely on the fact that the victim is authenticated via cookies or other authentication headers that the browser automatically includes in requests.”
+   *      source: https://security.stackexchange.com/questions/232936/how-to-prevent-csrf-attacks-on-a-rest-api-when-using-windows-authentication
+   *
+   * 3. CSRF via GET is only risky if the endpoint changes application state, the ladok mellanlager endpoint that we use today to get the data does is a read-only API.
+   *    - “CSRF attacks are only possible if the request changes the state of the application. If the request is read-only, it cannot change the state of the application.”
+   *     source: https://security.stackexchange.com/questions/115794/should-i-use-csrf-protection-for-get-requests
+   *
+   * 5. CSRF attacks are blind: even if a request were triggered, the attacker cannot read its response.
+   *    - “CRSF attacks are blind. They typically send a request without being able to read the result … Same Origin Policy.”
+   *      source: https://owasp.org/www-community/attacks/csrf
+   *
+   * Detectify CSRF False Positive: We can mark the Detectify finding as a False Positive, since:
+   *   - All requests are server-side and read-only.
+   *   - Browser sends no credentials automatically.
+   *   - No state is changed, no sensitive data is exposed.
+   *   - Pattern is fundamentally safe from CSRF exploitation.
+   */
+
   return (
     <form
       onSubmit={handleSubmit}
       name="statistics-options-choice"
+      method="GET"
       style={{
         display: 'block',
       }}


### PR DESCRIPTION
I had and investigation on this warning by detectify and here is the result of the investigation which is also added as a comment inside the code as well:




   * Detectify reports missing CSRF token on this form
   *
   * ✅ Why this is not a security issue:
   *
   * 1. It only triggers authenticated GET requests that do not modify server state.
   *    - “GET requests are to be used for idempotent requests, or requests that do not change state. These requests do not need to have anti‑CSRF tokens.”
   *      source: https://security.stackexchange.com/questions/115794/should-i-use-csrf-protection-for-get-requests
   *
   * 2. The request is made using a secret tokens stored in environment variables (never exposed to the browser).
   *    - “CSRF attacks rely on the fact that the victim is authenticated via cookies or other authentication headers that the browser automatically includes in requests.”
   *      source: https://security.stackexchange.com/questions/232936/how-to-prevent-csrf-attacks-on-a-rest-api-when-using-windows-authentication
   *
   * 3. CSRF via GET is only risky if the endpoint changes application state, the ladok mellanlager endpoint that we use today to get the data does is a read-only API.
   *    - “CSRF attacks are only possible if the request changes the state of the application. If the request is read-only, it cannot change the state of the application.”
   *     source: https://security.stackexchange.com/questions/115794/should-i-use-csrf-protection-for-get-requests
   *
   * 5. CSRF attacks are blind: even if a request were triggered, the attacker cannot read its response.
   *    - “CRSF attacks are blind. They typically send a request without being able to read the result … Same Origin Policy.”
   *      source: https://owasp.org/www-community/attacks/csrf
   *
   * Detectify CSRF False Positive: We can mark the Detectify finding as a False Positive, since:
   *   - All requests are server-side and read-only.
   *   - Browser sends no credentials automatically.
   *   - No state is changed, no sensitive data is exposed.
   *   - Pattern is fundamentally safe from CSRF exploitation.

Based on the instructions here ([Vulnerabilities page](https://support.detectify.com/support/solutions/articles/48001231329-vulnerabilities-page) ); We have two options: 
1. Tagging the finding as False Positive: which I recommend
2. Tagging the finding as Accepted Risk: We can mark this tag if False Positive tag did not work we were still getting the warning.

I added this details as a comment in the task as well: https://kth-se.atlassian.net/browse/KUI-1553