### PR TITLE
deps(KUI-2021): upgrade om-kursen-ladok-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@kth/kth-node-web-common": "9.4.1",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
-        "@kth/om-kursen-ladok-client": "^2.2.1",
+        "@kth/om-kursen-ladok-client": "^2.3.0",
         "@kth/server": "^4.1.0",
         "@kth/session": "^3.0.9",
         "@kth/style": "^1.4.2",
@@ -2834,9 +2834,9 @@
       "integrity": "sha512-MsMDU6FG6xYgglk5sitlLV3jYIGXjGaJsFup1Bl8qapPAgfDoDMq9PqrevEInvdDOPcsekKsUYhPPWjMCTNfXg=="
     },
     "node_modules/@kth/ladok-mellanlager-client": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-1.0.2.tgz",
-      "integrity": "sha512-iIKSwxQswg+fBsILZTQWzj+gA5aCqThmzPtmi6zze3HuKdFoxqc5KfHQQdepKnGsz3PufOF1lRxo02eszlUktg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@kth/ladok-mellanlager-client/-/ladok-mellanlager-client-1.1.0.tgz",
+      "integrity": "sha512-wyBAxYsoEkTqznamKPDSnuF/Hq5WTeRtMwqIVGj/71bqT+TGPVASKqFC/p683Z+VxKdpQSYdo4c0fRbIo4jGzw==",
       "dependencies": {
         "openapi-fetch": "^0.13.0"
       }
@@ -2859,12 +2859,12 @@
       }
     },
     "node_modules/@kth/om-kursen-ladok-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-2.2.1.tgz",
-      "integrity": "sha512-n60Ixkc+wZWVdVirAr/q+uHkPSvWIuwtfUY9xvSv5oa6pP6sH6YlsFLrojC/Jw1aEf0nfnu5cSYsMMbuI9RAjA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@kth/om-kursen-ladok-client/-/om-kursen-ladok-client-2.3.0.tgz",
+      "integrity": "sha512-dZTMZX8YLuHMQCnKPsa85P0TtqrHsK60KV+MecV3mP7PbgZo8qMM2VT/IanGAvPTypNByS0z/HL+88bqMCYmrQ==",
       "dependencies": {
         "@kth/ladok-attributvarde-utils": "1.0.3",
-        "@kth/ladok-mellanlager-client": "1.0.2",
+        "@kth/ladok-mellanlager-client": "1.1.0",
         "date-fns": "^4.1.0",
         "showdown": "^2.1.0"
       }
@@ -12583,6 +12583,7 @@
       "version": "0.13.8",
       "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.8.tgz",
       "integrity": "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==",
+      "license": "MIT",
       "dependencies": {
         "openapi-typescript-helpers": "^0.0.15"
       }
@@ -12590,7 +12591,8 @@
     "node_modules/openapi-typescript-helpers": {
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@kth/kth-node-web-common": "9.4.1",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.3.1",
-    "@kth/om-kursen-ladok-client": "^2.2.1",
+    "@kth/om-kursen-ladok-client": "^2.3.0",
     "@kth/server": "^4.1.0",
     "@kth/session": "^3.0.9",
     "@kth/style": "^1.4.2",


### PR DESCRIPTION
## 📌 Summary

Fixes https://kth-se.atlassian.net/browse/KUI-2021 

---

## 🔍 Changes

- Upgraded `@kth/om-kursen-ladok-client` to `2.3.0`which is not using slim endpoints. 

---

## ✅ Checklist (Author)

- [x] Code builds locally without errors
- [x] Tests added/updated and passing
- [x] Linting/formatting applied
- [x] No sensitive data in the diff
- [x] No stray console.logs in the diff
- [x] No stray comments in the diff
- [x] Docs/README/CHANGELOG updated (if needed)
- [ ] ~~Sufficient logging~~ Left out for future discussion
- [ ] ~~Errors are handled accordingly~~ Left out for future discussion

---

## 🧪 Testing & Verification

<!-- what has been done in terms of unit/automated tests -->
<!--- how to test/confirm manually -->
<!-- How did you test this? Steps/screenshots for reviewers. -->

Check that the following course pages are up and running:

1. http://localhost:3000/student/kurser/kurs/DD2434
2. http://localhost:3000/student/kurser/kurs/II1307
3. http://localhost:3000/student/kurser/kurs/AD12DA

---

## ⚠️ Impact / Risks

No known risks.

---

## 🚧 Out of Scope

Left out better handling of api fails. We need to discuss this further as a group and decide on to handle it.

---

## 📦 Downstream apps

None.