### PR TITLE
KUI-1763: Fix breadcrumb issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@kth/appinsights": "^0.6.0",
         "@kth/cortina-block": "^7.1.1",
         "@kth/kth-node-response": "^1.0.8",
-        "@kth/kth-node-web-common": "9.4.1",
+        "@kth/kth-node-web-common": "^9.6.1",
         "@kth/log": "^4.0.7",
         "@kth/monitor": "^4.3.1",
         "@kth/om-kursen-ladok-client": "^2.4.0",
@@ -2992,9 +2992,9 @@
       "license": "MIT"
     },
     "node_modules/@kth/kth-node-web-common": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.4.1.tgz",
-      "integrity": "sha512-Jx9H7evonSjfav1R0b1uy+/XdbeNrwu9aDyvMCMiQTjF7ZM6RJiVGYLVwSYK2SSRFCrIc0XG19D15UKWlaYdqw==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@kth/kth-node-web-common/-/kth-node-web-common-9.6.1.tgz",
+      "integrity": "sha512-vovHddnsI0FrqY/BNeJZtqGC/mb//vmQ6q8T4GVPhVvKYGDxNHrg3xbD2LJuGayoKM/ZEvi8HGlkgG3l0cMR4w==",
       "license": "MIT",
       "dependencies": {
         "@kth/cortina-block": "^5.1.1",
@@ -3002,7 +3002,7 @@
         "entities": "^2.2.0",
         "handlebars": "^4.7.8",
         "kth-node-i18n": "^1.0.18",
-        "kth-node-redis": "^3.3.0",
+        "kth-node-redis": "^3.4.0",
         "locale": "^0.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@kth/appinsights": "^0.6.0",
     "@kth/cortina-block": "^7.1.1",
     "@kth/kth-node-response": "^1.0.8",
-    "@kth/kth-node-web-common": "9.4.1",
+    "@kth/kth-node-web-common": "^9.6.1",
     "@kth/log": "^4.0.7",
     "@kth/monitor": "^4.3.1",
     "@kth/om-kursen-ladok-client": "^2.4.0",

--- a/public/css/kursinfo-web.scss
+++ b/public/css/kursinfo-web.scss
@@ -20,6 +20,7 @@
 @use '~@kth/style/scss/components/content.scss';
 @use '~@kth/style/scss/components/local-navigation.scss';
 @use '~@kth/style/scss/components/kpm.scss';
+@use '@kth/style/scss/components/breadcrumbs.scss';
 
 @import 'shared';
 
@@ -374,7 +375,7 @@ div::-webkit-scrollbar-thumb {
 
 .kth-alert {
   max-width: 700px;
-  
+
   h4 {
     margin-block-start: 0.5rem !important;
   }


### PR DESCRIPTION
# Summary

This fixes the issue where breadcrumbs were listed in an ordered list instead of displayed as specified.

<img width="622" height="74" alt="image" src="https://github.com/user-attachments/assets/788ea660-564b-49d5-99a2-a23cf865d083" />

# Changes
Only change required was to import a breadcrumb.scss from kth-style.

# Test
Runs locally. http://localhost:3000/student/kurser/kurs/SF1624